### PR TITLE
Add 'serial' permission to io2012 app.

### DIFF
--- a/io2012-presentation/manifest.json
+++ b/io2012-presentation/manifest.json
@@ -14,6 +14,7 @@
     "128": "images/icon-128.png"
   },
   "permissions": [
+    "serial",
     "storage",
     "videoCapture"
   ]


### PR DESCRIPTION
Required for servo (the video demo) to work.
