### PR TITLE
Add setConflictResolutionPolicy checkbox to syncfs-editor

### DIFF
--- a/syncfs-editor/css/editor.css
+++ b/syncfs-editor/css/editor.css
@@ -21,6 +21,11 @@ body {
   clear: both;
 }
 
+#conflict-policy {
+  float: right;
+  font-size: 12px;
+}
+
 #log {
   color: #666;
   font-size: 12px;

--- a/syncfs-editor/js/filer.js
+++ b/syncfs-editor/js/filer.js
@@ -1,7 +1,7 @@
-Filer = function(filesystem, container, editor) {
+Filer = function(filesystem, container, editor, isSyncable) {
   this.filesystem = filesystem;
   this.editor = editor;
-  this.isSyncable = (filesystem.name.indexOf('Syncable') != -1);
+  this.isSyncable = isSyncable;
 
   // Directory path => ul node mapping.
   var nodes = {};

--- a/syncfs-editor/js/main.js
+++ b/syncfs-editor/js/main.js
@@ -13,16 +13,18 @@ document.addEventListener(
   }
 );
 
-function onFileSystemOpened(fs) {
+function onFileSystemOpened(fs, isSyncable) {
+  log('Got Syncable FileSystem.');
   console.log('Got FileSystem:' + fs.name);
   var editor = new Editor(fs, 'editor');
-  var filer = new Filer(fs, 'filer', editor);
+  var filer = new Filer(fs, 'filer', editor, isSyncable);
   editor.filer = filer;
 }
 
 function openTemporaryFileSystem() {
   $('#fs-temporary').classList.add('selected');
   $('#fs-syncable').classList.remove('selected');
+  hide('#conflict-policy')
   webkitRequestFileSystem(TEMPORARY, 1024,
                           onFileSystemOpened,
                           error.bind(null, 'requestFileSystem'));
@@ -36,11 +38,27 @@ function openSyncableFileSystem() {
   }
   $('#fs-syncable').classList.add('selected');
   $('#fs-temporary').classList.remove('selected');
+  if (chrome.syncFileSystem.setConflictResolutionPolicy) {
+    chrome.syncFileSystem.setConflictResolutionPolicy('last_write_win');
+    show('#conflict-policy')
+  }
+  log('Obtaining syncable FileSystem...');
   chrome.syncFileSystem.requestFileSystem(function (fs) {
     if (chrome.runtime.lastError) {
       error('requestFileSystem: ' + chrome.runtime.lastError.message);
+      $('#fs-syncable').classList.remove('selected');
+      hide('#conflict-policy')
       return;
     }
-    onFileSystemOpened(fs);
+    onFileSystemOpened(fs, true);
   });
 }
+
+$('#conflict-policy').addEventListener('click', function() {
+  if ($('#auto-conflict-resolve').checked)
+    policy = 'last_write_win';
+  else
+    policy = 'manual';
+  chrome.syncFileSystem.setConflictResolutionPolicy(policy);
+  log('Changed conflict resolution policy to: ' + policy);
+});

--- a/syncfs-editor/main.html
+++ b/syncfs-editor/main.html
@@ -11,6 +11,11 @@
 </head>
 <body>
   <div id="fs-selector">
+    <div id="conflict-policy" class="hide">
+      <input id="auto-conflict-resolve" type="checkbox" checked>
+      Resolves Conflicts Automatically
+      </input>
+    </div>
     <button id="fs-syncable" class="fs-button">Syncable</button>
     <button id="fs-temporary" class="fs-button">Temporary</button>
   </div>

--- a/syncfs-editor/manifest.json
+++ b/syncfs-editor/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SyncFS editor",
-  "version": "0.286",
+  "version": "0.287",
   "manifest_version": 2,
   "description": "SyncFS editor (syncFileSystem sample)",
   "icons": {


### PR DESCRIPTION
As the canary syncFileSystem API starts to automatically resolve
conflicts and to supports 'manual' and 'last_write_win' conflict
resolution policies.
