### PR TITLE
Update dojo README to refer to the .crx

### DIFF
--- a/dojo/README.md
+++ b/dojo/README.md
@@ -2,7 +2,7 @@ Dojo
 ====
 This directory contains a script (build.sh) to generate an "one-app-to-rule-them-all": an app that executes all the other apps in the repository.
 
-To create the app, run build.sh on your Mac or Linux. It is necessary to have Perl installed (MacOsX and Linux both have by default). The generated kitchen-sink app will be in the build/ dir.
+To create the app, run build.sh on your Mac or Linux. It is necessary to have Perl installed (MacOsX and Linux both have by default). The generated kitchen-sink app will be in `dojo.crx`.
 
 Special thanks to @tomtasche for the idea and for the non-automatic implementation, which ultimately resulted in this script.
 


### PR DESCRIPTION
Used to refer to the generated app appearing in a `build/` subdirectory, which is no longer the case.
