### PR TITLE
telnet: update API to match current stable

### DIFF
--- a/telnet/README.md
+++ b/telnet/README.md
@@ -5,13 +5,12 @@ Renders it in glorious ANSIColor for your viewing joy.
 
 * TCP client
 * ANSI color renderer
-* DNS resolver [Deprecated]
 
 ## Resources
 
-* [Socket API](http://developer.chrome.com/trunk/apps/socket.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Socket API](http://developer.chrome.com/apps/socket.html)
+* [Runtime](http://developer.chrome.com/apps/app_runtime.html)
+* [Window](http://developer.chrome.com/apps/app_window.html)
 
 ## Credits
 

--- a/telnet/manifest.json
+++ b/telnet/manifest.json
@@ -13,7 +13,6 @@
     }
   },
   "permissions": [
-    "experimental",
     {"socket": [
       "tcp-connect:*:*"
     ]}

--- a/telnet/tcp-client.js
+++ b/telnet/tcp-client.js
@@ -19,8 +19,7 @@ Author: Boris Smus (smus@chromium.org)
 (function(exports) {
 
   // Define some local variables here.
-  var socket = chrome.socket || chrome.experimental.socket;
-  var dns = chrome.experimental.dns;
+  var socket = chrome.socket;
 
   /**
    * Creates an instance of the client
@@ -54,14 +53,10 @@ Author: Boris Smus (smus@chromium.org)
    * @param {Function} callback The function to call on connection
    */
   TcpClient.prototype.connect = function(callback) {
-    // First resolve the hostname to an IP.
-    dns.resolve(this.host, function(result) {
-      this.addr = result.address;
-      socket.create('tcp', {}, this._onCreate.bind(this));
+    socket.create('tcp', {}, this._onCreate.bind(this));
 
-      // Register connect callback.
-      this.callbacks.connect = callback;
-    }.bind(this));
+    // Register connect callback.
+    this.callbacks.connect = callback;
   };
 
   /**
@@ -112,7 +107,7 @@ Author: Boris Smus (smus@chromium.org)
   TcpClient.prototype._onCreate = function(createInfo) {
     this.socketId = createInfo.socketId;
     if (this.socketId > 0) {
-      socket.connect(this.socketId, this.addr, this.port, this._onConnectComplete.bind(this));
+      socket.connect(this.socketId, this.host, this.port, this._onConnectComplete.bind(this));
       this.isConnected = true;
     } else {
       error('Unable to create socket');


### PR DESCRIPTION
Let's drop the DNS API usage since chrome.socket now supports that part
by itself (hostname->IP lookup).

The chrome.socket API as found in Chrome 24 (and current stable is 28)
is now fully usable w/out experimental markings.
