### PR TITLE
Add new alwaysOnTop window property to the Window State sample

### DIFF
--- a/window-state/window.html
+++ b/window-state/window.html
@@ -23,7 +23,7 @@
       <button id="restore">Restore</button>
       <button id="hide">Hide</button>
       <button id="show">Show</button>
-      <label><input type="checkbox" id="alwaysOnTop" />Always On Top</label>
+      <label id="alwaysOnTopLabel"><input type="checkbox" id="alwaysOnTop" />Always On Top</label>
       <br>
       <button id="move">Move To (L,T)</button> /
       <button id="resize">Resize To (W,H)</button> /
@@ -51,7 +51,7 @@
       <label>Min<input type="number" class="size" id="newWindowHeightMin" step=1 /></label>
       <label><input type="number" class="size" id="newWindowHeightMax" step=1 />Max Height</label>
       <label><input type="checkbox" id="newWindowResizable" checked/>Resizable</label>
-      <label><input type="checkbox" id="newWindowOnTop" />Always On Top</label>
+      <label id="newWindowOnTopLabel"><input type="checkbox" id="newWindowOnTop" />Always On Top</label>
       <br>
       <label><input type="radio" name="newWindowHidden" value="visible" checked/>Visible</label>
       <label><input type="radio" name="newWindowHidden" value="hidden" />Hidden, then shown</label>

--- a/window-state/window.js
+++ b/window-state/window.js
@@ -5,6 +5,10 @@ var fullscreenchangeCount = 0;
 var fullscreenerrorCount = 0;
 var newWindowOffset = 100;
 
+// chrome.app.window alwaysOnTop property is supported in Chrome M32 or later.
+// The option will be hidden if not supported in the current browser version.
+var isAlwaysOnTopSupported = typeof(chrome.app.window.current().setAlwaysOnTop) !== 'undefined';
+
 // Helper functions
 $ = function(selector) { return document.querySelector(selector); }
 
@@ -31,7 +35,8 @@ function createNewWindow(optionsDictionary) {
   setIfANumber(optionsDictionary, 'minHeight', parseInt($('#newWindowHeightMin').value));
   setIfANumber(optionsDictionary, 'maxHeight', parseInt($('#newWindowHeightMax').value));
   optionsDictionary.resizable = $('#newWindowResizable').checked;
-  optionsDictionary.alwaysOnTop = $('#newWindowOnTop').checked;
+  if (isAlwaysOnTopSupported)
+    optionsDictionary.alwaysOnTop = $('#newWindowOnTop').checked;
 
   optionsDictionary.hidden = $('[value=hidden]').checked;
   var showAfterCreated = function (win) {
@@ -218,4 +223,9 @@ chrome.app.window.current().onBoundsChanged.addListener(updateCurrentStateReadou
 setInterval(updateCurrentStateReadout, 1000);
 
 // Set initial value of always on top
-$('#alwaysOnTop').checked = chrome.app.window.current().isAlwaysOnTop();
+if (isAlwaysOnTopSupported) {
+  $('#alwaysOnTop').checked = chrome.app.window.current().isAlwaysOnTop();
+} else {
+  $('#alwaysOnTopLabel').style.visibility = 'hidden';
+  $('#newWindowOnTopLabel').style.visibility = 'hidden';
+}


### PR DESCRIPTION
The chrome.app.window alwaysOnTop property will be pushed to stable in M32.  Add a demo of this property to the existing Window State sample app.  The UI controls for this new option will be hidden in older Chrome versions which do not support the property.

See:
http://crrev.com/48113024
http://crbug.com/171597
