### PR TITLE
Don't JSON.stringify() the body of a request.

### DIFF
--- a/gapi-chrome-apps-lib/gapi-chrome-apps.js
+++ b/gapi-chrome-apps-lib/gapi-chrome-apps.js
@@ -93,7 +93,7 @@
     xhr.setRequestHeader('Authorization', 'Bearer ' + access_token);
     if (typeof args.body !== 'undefined') {
       xhr.setRequestHeader('content-type', 'application/json');
-      xhr.send(JSON.stringify(args.body));
+      xhr.send(args.body);
     } else {
       xhr.send();
     }


### PR DESCRIPTION
The body that is passed in should already be a string [1], so JSON.stringify()ing it is unnecessary and incorrect.

[1] https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiclientrequest
