### PR TITLE
Window State sample app: Add alwaysOnTopWindows permission to manifest

### DIFF
--- a/window-state/manifest.json
+++ b/window-state/manifest.json
@@ -10,5 +10,5 @@
       "scripts": ["background.js"]
     }
   },
-  "permissions": ["fullscreen"]
+  "permissions": ["fullscreen", "alwaysOnTopWindows"]
 }


### PR DESCRIPTION
The alwaysOnTop property of chrome.app.window now requires an "alwaysOnTopWindows" permission to be declared in the manifest.  The Window State sample app needs to be updated.
