### PR TITLE
Removed trunk/ from docserver URLs

### DIFF
--- a/analytics/README.md
+++ b/analytics/README.md
@@ -13,8 +13,8 @@ Offline is also supported. See more at the [project wiki](https://github.com/Goo
 
 ## Resources
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 * [chrome-platform-analytics](https://github.com/GoogleChrome/chrome-platform-analytics/wiki)
 
      

--- a/appengine_channelapi/app/main.js
+++ b/appengine_channelapi/app/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {

--- a/appsquare/README.md
+++ b/appsquare/README.md
@@ -5,7 +5,7 @@
 
 This is a basic Foursquare client implemented as a packaged app.
 
-It just displays recent checkins of the logged in user's friends. To log into Foursquare, it uses the [identity API](http://developer.chrome.com/trunk/apps/identity.html) (specfically, the `launchWebAuthFlow` method). Once it gets the OAuth token, it uses the [storage API](http://developer.chrome.com/trunk/apps/storage.html) to persist it. It also uses the [W3C Geolocation API](http://www.w3.org/TR/geolocation-API/) to pass in the current location to the Foursquare API.
+It just displays recent checkins of the logged in user's friends. To log into Foursquare, it uses the [identity API](http://developer.chrome.com/apps/identity.html) (specfically, the `launchWebAuthFlow` method). Once it gets the OAuth token, it uses the [storage API](http://developer.chrome.com/apps/storage.html) to persist it. It also uses the [W3C Geolocation API](http://www.w3.org/TR/geolocation-API/) to pass in the current location to the Foursquare API.
 
 When running it unpacked, it will normally have a different ID (the unpacked
 extension ID is a hash of the path on disk). However, this will result in the
@@ -19,9 +19,9 @@ The key *must* be removed before uploading it to the store.
 
 ## Resources
 
-* [Identity](http://developer.chrome.com/trunk/apps/app.identity.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Identity](http://developer.chrome.com/apps/app.identity.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/appsquare/assets/screenshot_1280_800.png)

--- a/browser/README.md
+++ b/browser/README.md
@@ -3,7 +3,7 @@
 
 # Browser
 
-Sample that shows how to use the [webview tag](http://developer.chrome.com/trunk/apps/app_external.html#webview)
+Sample that shows how to use the [webview tag](http://developer.chrome.com/apps/app_external.html#webview)
 in an app to create a mini browser.
 
 The app's main window contains a `<webview>` that is sized to fit most of it
@@ -16,8 +16,8 @@ reliability of your application.
 
 ## Resources
 
-* [Webview](http://developer.chrome.com/trunk/apps/app_external.html#webview)
-* [Permissions](http://developer.chrome.com/trunk/apps/manifest.html#permissions)
+* [Webview](http://developer.chrome.com/apps/app_external.html#webview)
+* [Permissions](http://developer.chrome.com/apps/manifest.html#permissions)
 
      
 ## Screenshot

--- a/browser/main.js
+++ b/browser/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   runApp();
@@ -11,7 +11,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
 /**
  * Listens for the app restarting then re-creates the window.
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
  */
 chrome.app.runtime.onRestarted.addListener(function() {
   runApp();
@@ -20,7 +20,7 @@ chrome.app.runtime.onRestarted.addListener(function() {
 /**
  * Creates the window for the application.
  *
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 function runApp() {
   chrome.app.window.create('browser.html', {

--- a/calculator/README.md
+++ b/calculator/README.md
@@ -11,8 +11,8 @@ DOM manipulation.
 
 ## APIs
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/calculator/main.js
+++ b/calculator/main.js
@@ -8,7 +8,7 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('calculator.html', {

--- a/camera-capture/README.md
+++ b/camera-capture/README.md
@@ -9,9 +9,9 @@ to be set in the manifest file.
 
 ## APIs
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
-* [videoCapture and audioCapture](http://developer.chrome.com/trunk/apps/manifest.html#permissions)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
+* [videoCapture and audioCapture](http://developer.chrome.com/apps/manifest.html#permissions)
 
      
 ## Screenshot

--- a/camera-capture/app.js
+++ b/camera-capture/app.js
@@ -21,7 +21,7 @@ Author: Eric Bidelman (ericbidelman@chromium.org)
  * both video and audio. Requires the permissions
  * for audio and video to be set in the manifest.
  *
- * @see http://developer.chrome.com/trunk/apps/manifest.html#permissions
+ * @see http://developer.chrome.com/apps/manifest.html#permissions
  */
 function getCamera() {
   navigator.webkitGetUserMedia({audio: true, video: true}, function(stream) {

--- a/camera-capture/background.js
+++ b/camera-capture/background.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {

--- a/clock/README.md
+++ b/clock/README.md
@@ -7,9 +7,9 @@ A widget-like application that provides a world clock, an alarm, a timer and a s
 
 ## APIs
 
-* [Sync Storage API](http://developer.chrome.com/trunk/apps/storage.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Sync Storage API](http://developer.chrome.com/apps/storage.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/clock/main.js
+++ b/clock/main.js
@@ -8,7 +8,7 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
  chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {

--- a/context-menu/README.md
+++ b/context-menu/README.md
@@ -3,15 +3,15 @@
 
 # Context menus
 
-Sample that shows how to use the [context menu API](http://developer.chrome.com/trunk/apps/contextMenus.html) in an app to manage various application context menus, such as menus that only apply to particular windows, menus that apply to selections or media types, and context menus that work on the app launcher.
+Sample that shows how to use the [context menu API](http://developer.chrome.com/apps/contextMenus.html) in an app to manage various application context menus, such as menus that only apply to particular windows, menus that apply to selections or media types, and context menus that work on the app launcher.
 
 A single context menu structure is normally global to the entire app, and thus all windows would have the same menu. This sample uses a `focus` event handler in each window to detect when a window is brought to the foreground. When it is, the contents of the context menu are updated with that window's commands, while leaving the other menus intact. The `chrome.contextMenus.onClicked` event handler also only handles events that occur in that window.
 
 ## APIs
 
-* [Context menu API](http://developer.chrome.com/trunk/apps/contextMenus.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Context menu API](http://developer.chrome.com/apps/contextMenus.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
      

--- a/dart/README.md
+++ b/dart/README.md
@@ -9,8 +9,8 @@ if you want to recompile dart to JS. See the correct, CSP compatible, command-li
 
 ## APIs
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/dart/js/main.js
+++ b/dart/js/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('clock.html',

--- a/dialog-element/README.md
+++ b/dialog-element/README.md
@@ -28,6 +28,6 @@ dialog.addEventListener("cancel", function(evt) {
 
 ## Resources
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      

--- a/dialog-element/main.js
+++ b/dialog-element/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   // Center window on screen.

--- a/diff/README.md
+++ b/diff/README.md
@@ -9,10 +9,10 @@ A non-trivial application to diff two files choosen by the user. This app shows 
 
 ## APIs
 
-* [Local Storage API](http://developer.chrome.com/trunk/apps/storage.html) to save history of selected files
-* [Filesystem API](http://developer.chrome.com/trunk/apps/app_storage.html) to allow the user to pick arbitrary files from the disk and save them back.
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Local Storage API](http://developer.chrome.com/apps/storage.html) to save history of selected files
+* [Filesystem API](http://developer.chrome.com/apps/app_storage.html) to allow the user to pick arbitrary files from the disk and save them back.
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/filesystem-access/README.md
+++ b/filesystem-access/README.md
@@ -12,7 +12,7 @@ NOTE: This sample requires Milestone 31 or later of Chrome, since it uses the ne
 
 ## APIs
 
-* [chrome.fileSystem](http://developer.chrome.com/trunk/apps/fileSystem.html)
+* [chrome.fileSystem](http://developer.chrome.com/apps/fileSystem.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/filesystem-access/assets/screenshot_1280_800.png)

--- a/frameless-window/README.md
+++ b/frameless-window/README.md
@@ -9,8 +9,8 @@ Caveat: `-webkit-app-region: drag;` *will* disable some customizations such as c
 
 ## APIs
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/gdrive/README.md
+++ b/gdrive/README.md
@@ -10,4 +10,4 @@ To upload files: drag in files from the desktop onto the app.
 
 ## APIs
 
-* [Identity](http://developer.chrome.com/trunk/apps/identity.html)
+* [Identity](http://developer.chrome.com/apps/identity.html)

--- a/github-auth/README.md
+++ b/github-auth/README.md
@@ -4,7 +4,7 @@
 # GitHub Auth
 
 A sample application that uses the
-[Identity API](https://developer.chrome.com/trunk/apps/identity.html) to
+[Identity API](https://developer.chrome.com/apps/identity.html) to
 request identification information about the user's GitHub account. After user
 logs on to GitHub and authorizes the application to use their information, both
 users name and email address (if available) will be displayed.
@@ -15,9 +15,9 @@ Account check out the [Identity sample application](https://github.com/GoogleChr
 
 ## APIs
 
-* [Identity](https://developer.chrome.com/trunk/apps/identity.html)
-* [Runtime](https://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](https://developer.chrome.com/trunk/apps/app.window.html)
+* [Identity](https://developer.chrome.com/apps/identity.html)
+* [Runtime](https://developer.chrome.com/apps/app.runtime.html)
+* [Window](https://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -32,8 +32,8 @@ and, at that point, creates a window using a basic HTML page, index.html, as the
 
 ## Resources
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/hello-world/assets/screenshot_1280_800.png)

--- a/hello-world/main.js
+++ b/hello-world/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   // Center window on screen.

--- a/identity/README.md
+++ b/identity/README.md
@@ -4,7 +4,7 @@
 # Identity
 
 A sample application that uses the
-[Identity API](https://developer.chrome.com/trunk/apps/identity.html) to
+[Identity API](https://developer.chrome.com/apps/identity.html) to
 request information of the logged in user and present this info on the screen.
 If the user has a profile picture, an XMLHttpRequest request is also sent to
 grab the image and show it in the app.
@@ -15,7 +15,7 @@ you should use the launchWebAuthFlow method instead.
 
 ## APIs
 
-* [Identity](http://developer.chrome.com/trunk/apps/app.identity.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Identity](http://developer.chrome.com/apps/app.identity.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 

--- a/instagram-auth/README.md
+++ b/instagram-auth/README.md
@@ -5,7 +5,7 @@
 
 This is a basic Instagram client implemented as a packaged app.  This demonstration simply displays the users logged-in view as raw JSON.
 
-To log into Instagram, it uses the [identity API](http://developer.chrome.com/trunk/apps/identity.html) (specfically, the `launchWebAuthFlow` method). Once it gets the OAuth token it makes a request to an authenticated endpoint to get the JSON feed of the user's view.
+To log into Instagram, it uses the [identity API](http://developer.chrome.com/apps/identity.html) (specfically, the `launchWebAuthFlow` method). Once it gets the OAuth token it makes a request to an authenticated endpoint to get the JSON feed of the user's view.
 
 When running it unpacked, it will normally have a different ID (the unpacked
 extension ID is a hash of the path on disk). However, this will result in the
@@ -20,6 +20,6 @@ The key *must* be removed before uploading it to the store.
 
 ## Resources
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
-* [Identity](http://developer.chrome.com/trunk/apps/app.identity.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
+* [Identity](http://developer.chrome.com/apps/app.identity.html)

--- a/instagram-auth/main.js
+++ b/instagram-auth/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function(intentData) {
     chrome.app.window.create('index.html', {

--- a/mdns-browser/README.md
+++ b/mdns-browser/README.md
@@ -8,9 +8,9 @@ This is a non-trivial sample which uses the UDP multicast support in Chrome Pack
 
 ## APIs
 
-* [UDP Network](http://developer.chrome.com/trunk/apps/app_network.html#udp)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [UDP Network](http://developer.chrome.com/apps/app_network.html#udp)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/media-gallery/README.md
+++ b/media-gallery/README.md
@@ -8,8 +8,8 @@ This is a sample application that uses the [media gallery](http://developer.chro
 ## APIs
 
 * [Media gallery](http://developer.chrome.com/apps/mediaGalleries.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/messaging/README.md
+++ b/messaging/README.md
@@ -4,9 +4,9 @@ This sample shows how to communicate between two apps or one app and one extensi
 
 ## Resources
 
-* [Messaging](https://developer.chrome.com/trunk/apps/runtime.html#method-sendMessage)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Messaging](https://developer.chrome.com/apps/runtime.html#method-sendMessage)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/messaging/assets/screenshot_1280_800.png)

--- a/messaging/app1/main.js
+++ b/messaging/app1/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html',

--- a/messaging/app2/main.js
+++ b/messaging/app2/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html',

--- a/mini-code-edit/README.md
+++ b/mini-code-edit/README.md
@@ -7,9 +7,9 @@ A non-trivial sample with basic features of a code editor, like syntax detection
 
 ## APIs
 
-* [chrome.fileSystem](http://developer.chrome.com/trunk/apps/fileSystem.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [chrome.fileSystem](http://developer.chrome.com/apps/fileSystem.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/mini-code-edit/background.js
+++ b/mini-code-edit/background.js
@@ -8,7 +8,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
 
 /** 
 * Set up the Commands listener event
-* @see http://developer.chrome.com/trunk/apps/commands.html
+* @see http://developer.chrome.com/apps/commands.html
 */
 chrome.commands.onCommand.addListener(function(command) {
    console.log("Command triggered: " + command);

--- a/multicast/README.md
+++ b/multicast/README.md
@@ -11,11 +11,11 @@ To support multicast socket messaging in your local network requires the support
 
 __Warning: This is a simple chatting app demonstrating the usage of multicast socket Chrome app API. It is not designed for reliable communication. Privacy and reachability of the message is NOT guaranteed. It is also possible that a user is able to send to another user while not being able to receive from the latter.__
 ## APIs
-* [Messaging](https://developer.chrome.com/trunk/apps/runtime.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Storage](http://developer.chrome.com/trunk/apps/storage.html)
-* [Socket](http://developer.chrome.com/trunk/apps/socket.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Messaging](https://developer.chrome.com/apps/runtime.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Storage](http://developer.chrome.com/apps/storage.html)
+* [Socket](http://developer.chrome.com/apps/socket.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/multicast/assets/screenshot_1280_800.png)

--- a/parrot-ar-drone/README.md
+++ b/parrot-ar-drone/README.md
@@ -30,8 +30,8 @@ _Please note: this has only been tested with an Xbox 360 controller_
 
 ## Resources
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 * [Socket](http://developer.chrome.com/apps/socket.html)
 
 _Thanks to felixge for the [Node AR Drone lib](https://github.com/felixge/node-ar-drone), which served as a helpful reference._

--- a/push-guestbook/README.md
+++ b/push-guestbook/README.md
@@ -1,7 +1,7 @@
 # Push Messaging Guestbook
 
 Sample that shows how to use the [Push Messaging
-API](http://developer.chrome.com/trunk/apps/pushMessaging.html) in an app.
+API](http://developer.chrome.com/apps/pushMessaging.html) in an app.
 
 How to install on your local machine:
 
@@ -39,9 +39,9 @@ How to install on your local machine:
 
 ## APIs
 
-* [Push Messaging API](http://developer.chrome.com/trunk/apps/pushMessaging.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Push Messaging API](http://developer.chrome.com/apps/pushMessaging.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/push-guestbook/assets/screenshot_1280_800.png)

--- a/push-messaging-roundtrip-sample/README.md
+++ b/push-messaging-roundtrip-sample/README.md
@@ -4,7 +4,7 @@
 # Push Messaging Roundtrip Sample App
 
 Sample that shows how to use the [Push Messaging
-API](http://developer.chrome.com/trunk/apps/pushMessaging.html) in an app.
+API](http://developer.chrome.com/apps/pushMessaging.html) in an app.
 
 Normally we don't expect you to send push messages from JS code, we normally
 expect that you will want to write a server which does the sending, but this app may
@@ -41,8 +41,8 @@ to write your client code.
 
 ## APIs
 
-* [Push Messaging API](http://developer.chrome.com/trunk/apps/pushMessaging.html)
-* [GCM for Chrome server API](http://developer.chrome.com/trunk/apps/cloudMessaging.html)     
+* [Push Messaging API](http://developer.chrome.com/apps/pushMessaging.html)
+* [GCM for Chrome server API](http://developer.chrome.com/apps/cloudMessaging.html)     
 
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/push-messaging-roundtrip-sample/assets/screenshot_1280_800.png)

--- a/push-sample-app/README.md
+++ b/push-sample-app/README.md
@@ -4,7 +4,7 @@
 # Push Sample App
 
 Sample that shows how to use the [Push Messaging
-API](http://developer.chrome.com/trunk/apps/pushMessaging.html) in an app.
+API](http://developer.chrome.com/apps/pushMessaging.html) in an app.
 
 How to install on your local machine:
 
@@ -38,8 +38,8 @@ curl -s -H "Authorization: Bearer $accesstoken" -H "Content-Type: application/js
 
 ## APIs
 
-* [Push Messaging API](http://developer.chrome.com/trunk/apps/pushMessaging.html)
-* [GCM for Chrome serverf API](http://developer.chrome.com/trunk/apps/cloudMessaging.html)     
+* [Push Messaging API](http://developer.chrome.com/apps/pushMessaging.html)
+* [GCM for Chrome serverf API](http://developer.chrome.com/apps/cloudMessaging.html)     
 
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/push-sample-app/assets/screenshot_1280_800.png)

--- a/restarted-demo/README.md
+++ b/restarted-demo/README.md
@@ -10,9 +10,9 @@ This demo app creates a new counter on launch and restores any existing counters
 
 ## APIs
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Storage](http://developer.chrome.com/trunk/apps/storage.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Storage](http://developer.chrome.com/apps/storage.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/restarted-demo/assets/screenshot_1280_800.png)

--- a/rich-notifications/README.md
+++ b/rich-notifications/README.md
@@ -12,7 +12,7 @@ in the system tray. This API is still in experimental state.
 
 ## Resources
 
-* [Notification API documentation](http://developer.chrome.com/trunk/apps/notifications.html)
+* [Notification API documentation](http://developer.chrome.com/apps/notifications.html)
 
 ## Screenshot
 

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -9,16 +9,16 @@ passes a counter variable. The sandboxed page uses the
 using the counter variable which is then passed back to the main page for rendering.
 
 The default packaged app Content Security Policy (CSP) value
-[disallows](http://developer.chrome.com/trunk/apps/app_csp.html) the use of
+[disallows](http://developer.chrome.com/apps/app_csp.html) the use of
 `eval()` or `new Function()` (or variants like `Function.apply()`) so using a
 sandbox is necessary for this process. To enable sandboxing in your app you
-add the `sandbox` property to your app's [manifest file](http://developer.chrome.com/trunk/apps/manifest.html#sandbox).
+add the `sandbox` property to your app's [manifest file](http://developer.chrome.com/apps/manifest.html#sandbox).
 
-See more info on [using eval safely in packaged apps](http://developer.chrome.com/trunk/apps/sandboxingEval.html).
+See more info on [using eval safely in packaged apps](http://developer.chrome.com/apps/sandboxingEval.html).
 
 ## APIs
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/sandbox/assets/screenshot_1280_800.png)

--- a/sandbox/main.js
+++ b/sandbox/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('mainpage.html',

--- a/sandboxed-content/README.md
+++ b/sandboxed-content/README.md
@@ -7,16 +7,16 @@ This sample creates a window containing a sandboxed iframe (`sandbox.html`).
 The sandbox uses `eval()` function to write some HTML to its own document.
 
 The default packaged app Content Security Policy (CSP) value
-[disallows](http://developer.chrome.com/trunk/apps/app_csp.html) the use of
+[disallows](http://developer.chrome.com/apps/app_csp.html) the use of
 `eval()` or `new Function()` (or variants like `Function.apply()`) so using a
 sandbox is necessary for this process. To enable sandboxing in your app you
-add the `sandbox` property to your app's [manifest file](http://developer.chrome.com/trunk/apps/manifest.html#sandbox).
+add the `sandbox` property to your app's [manifest file](http://developer.chrome.com/apps/manifest.html#sandbox).
 
-See more info on [using eval safely in packaged apps](http://developer.chrome.com/trunk/apps/sandboxingEval.html).
+See more info on [using eval safely in packaged apps](http://developer.chrome.com/apps/sandboxingEval.html).
 
 ## APIs
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
 
      
 ## Screenshot

--- a/sandboxed-content/main.js
+++ b/sandboxed-content/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('main.html',

--- a/serial-control-signals/README.md
+++ b/serial-control-signals/README.md
@@ -7,9 +7,9 @@ This sample demonstrates how you can send and receive control signals (DTR, RTS,
 
 ## APIs
 
-* [Serial API](http://developer.chrome.com/trunk/apps/app.hardware.html#serial)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Serial API](http://developer.chrome.com/apps/app.hardware.html#serial)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/serial-control-signals/assets/screenshot_1280_800.png)

--- a/serial/adkjs/README.md
+++ b/serial/adkjs/README.md
@@ -10,9 +10,9 @@ In the app directory, you will find the Chrome Packaged App.
 
 ## APIs
 
-* [Serial API](http://developer.chrome.com/trunk/apps/app.hardware.html#serial)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Serial API](http://developer.chrome.com/apps/app.hardware.html#serial)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/serial/adkjs/app/assets/screenshot_1280_800.png)

--- a/serial/ledtoggle/README.md
+++ b/serial/ledtoggle/README.md
@@ -19,9 +19,9 @@ for Chrome packaged apps.
 
 ## APIs
 
-* [Serial API](http://developer.chrome.com/trunk/apps/app.hardware.html#serial)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Serial API](http://developer.chrome.com/apps/app.hardware.html#serial)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/serial/ledtoggle/assets/screenshot_1280_800.png)

--- a/servo/README.md
+++ b/servo/README.md
@@ -10,9 +10,9 @@ This app displays a slider that, when dragged, causes a servo attached to an Ard
 
 ## APIs
 
-* [Serial API](http://developer.chrome.com/trunk/apps/app.hardware.html#serial)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Serial API](http://developer.chrome.com/apps/app.hardware.html#serial)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/servo/assets/screenshot_1280_800.png)

--- a/singleton/README.md
+++ b/singleton/README.md
@@ -3,13 +3,13 @@
 
 # Singleton window
 
-Sample that shows how to use the [window API](http://developer.chrome.com/trunk/apps/appWindow.html) in an app to have a "singleton" window app.
+Sample that shows how to use the [window API](http://developer.chrome.com/apps/appWindow.html) in an app to have a "singleton" window app.
 
 The app keeps track of its window in the background page. If none exists, or if it's closed, it creates a new one. Otherwise it re-focuses the existing one via `chrome.app.window.focus()`.
 
 ## APIs
 
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/singleton/assets/screenshot_1280_800.png)

--- a/singleton/main.js
+++ b/singleton/main.js
@@ -6,8 +6,8 @@ var singletonWindow;
  * that window is focused, otherwise a new window
  * is created and the reference stored for next time.
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('singleton.html', {

--- a/storage/README.md
+++ b/storage/README.md
@@ -7,9 +7,9 @@ A very basic application that demonstrates the Filesystem API. It allows you to 
 
 ## APIs
 
-* [Filesystem](http://developer.chrome.com/trunk/apps/app_storage.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Filesystem](http://developer.chrome.com/apps/app_storage.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/systemInfo/README.md
+++ b/systemInfo/README.md
@@ -7,12 +7,12 @@ Shows how to use experimental systemInfo APIs to query system information, such
 as CPU, memory and disk storage etc. 
 
 ## APIs
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
-* [Display](http://developer.chrome.com/trunk/apps/system_display.html)
-* [CPU](http://developer.chrome.com/trunk/apps/system_cpu.html)
-* [Memory](http://developer.chrome.com/trunk/apps/system_memory.html)
-* [Storage](http://developer.chrome.com/trunk/apps/system_storage.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
+* [Display](http://developer.chrome.com/apps/system_display.html)
+* [CPU](http://developer.chrome.com/apps/system_cpu.html)
+* [Memory](http://developer.chrome.com/apps/system_memory.html)
+* [Storage](http://developer.chrome.com/apps/system_storage.html)
 
 ## Screenshot
 

--- a/systemInfo/main.js
+++ b/systemInfo/main.js
@@ -8,7 +8,7 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
  chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {

--- a/tcpserver/README.md
+++ b/tcpserver/README.md
@@ -7,9 +7,9 @@ This is a sample that shows how you can run a network TCP server in a packaged a
 
 ## APIs
 
-* [Socket API](http://developer.chrome.com/trunk/apps/socket.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Socket API](http://developer.chrome.com/apps/socket.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/tcpserver/assets/screenshot_1280_800.png)

--- a/tcpserver/main.js
+++ b/tcpserver/main.js
@@ -5,8 +5,8 @@ var commandWindow;
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
 	if (commandWindow && !commandWindow.contentWindow.closed) {

--- a/tcpserver/tcp-server.js
+++ b/tcpserver/tcp-server.js
@@ -57,7 +57,7 @@ const DEFAULT_MAX_CONNECTIONS=5;
   /**
    * Static method to return available network interfaces.
    *
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-getNetworkList
+   * @see http://developer.chrome.com/apps/socket.html#method-getNetworkList
    *
    * @param {Function} callback The function to call with the available network
    * interfaces. The callback parameter is an array of
@@ -75,7 +75,7 @@ const DEFAULT_MAX_CONNECTIONS=5;
   /**
    * Connects to the TCP socket, and creates an open socket.
    *
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-create
+   * @see http://developer.chrome.com/apps/socket.html#method-create
    * @param {Function} callback The function to call on connection
    */
   TcpServer.prototype.listen = function(callback) {
@@ -88,7 +88,7 @@ const DEFAULT_MAX_CONNECTIONS=5;
   /**
    * Disconnects from the remote side
    *
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-disconnect
+   * @see http://developer.chrome.com/apps/socket.html#method-disconnect
    */
   TcpServer.prototype.disconnect = function() {
     if (this.serverSocketId) socket.disconnect(this.serverSocketId);
@@ -109,7 +109,7 @@ const DEFAULT_MAX_CONNECTIONS=5;
    * we go ahead and start listening for incoming connections.
    *
    * @private
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-connect
+   * @see http://developer.chrome.com/apps/socket.html#method-connect
    * @param {Object} createInfo The socket details
    */
   TcpServer.prototype._onCreate = function(createInfo) {
@@ -221,7 +221,7 @@ const DEFAULT_MAX_CONNECTIONS=5;
   /**
    * Sends a message down the wire to the remote side
    *
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-write
+   * @see http://developer.chrome.com/apps/socket.html#method-write
    * @param {String} msg The message to send
    * @param {Function} callback The function to call when the message has sent
    */
@@ -238,7 +238,7 @@ const DEFAULT_MAX_CONNECTIONS=5;
   /**
    * Disconnects from the remote side
    *
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-disconnect
+   * @see http://developer.chrome.com/apps/socket.html#method-disconnect
    */
   TcpConnection.prototype.disconnect = function() {
     if (this.socketId) socket.disconnect(this.socketId);
@@ -248,7 +248,7 @@ const DEFAULT_MAX_CONNECTIONS=5;
   /**
    * Checks for new data to read from the socket
    *
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-read
+   * @see http://developer.chrome.com/apps/socket.html#method-read
    * @private
    */
 

--- a/telnet/README.md
+++ b/telnet/README.md
@@ -12,9 +12,9 @@ Renders it in glorious ANSIColor for your viewing joy.
 
 ## Resources
 
-* [Socket API](http://developer.chrome.com/trunk/apps/socket.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Socket API](http://developer.chrome.com/apps/socket.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
 ## Credits
 

--- a/telnet/launch.js
+++ b/telnet/launch.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('terminal.html', {

--- a/telnet/tcp-client.js
+++ b/telnet/tcp-client.js
@@ -50,7 +50,7 @@ Author: Boris Smus (smus@chromium.org)
   /**
    * Connects to the TCP socket, and creates an open socket.
    *
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-create
+   * @see http://developer.chrome.com/apps/socket.html#method-create
    * @param {Function} callback The function to call on connection
    */
   TcpClient.prototype.connect = function(callback) {
@@ -67,7 +67,7 @@ Author: Boris Smus (smus@chromium.org)
   /**
    * Sends a message down the wire to the remote side
    *
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-write
+   * @see http://developer.chrome.com/apps/socket.html#method-write
    * @param {String} msg The message to send
    * @param {Function} callback The function to call when the message has sent
    */
@@ -93,7 +93,7 @@ Author: Boris Smus (smus@chromium.org)
   /**
    * Disconnects from the remote side
    *
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-disconnect
+   * @see http://developer.chrome.com/apps/socket.html#method-disconnect
    */
   TcpClient.prototype.disconnect = function() {
     socket.disconnect(this.socketId);
@@ -106,7 +106,7 @@ Author: Boris Smus (smus@chromium.org)
    * we go ahead and connect to the remote side.
    *
    * @private
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-connect
+   * @see http://developer.chrome.com/apps/socket.html#method-connect
    * @param {Object} createInfo The socket details
    */
   TcpClient.prototype._onCreate = function(createInfo) {
@@ -141,7 +141,7 @@ Author: Boris Smus (smus@chromium.org)
   /**
    * Checks for new data to read from the socket
    *
-   * @see http://developer.chrome.com/trunk/apps/socket.html#method-read
+   * @see http://developer.chrome.com/apps/socket.html#method-read
    */
   TcpClient.prototype._periodicallyRead = function() {
     socket.read(this.socketId, null, this._onDataRead.bind(this));

--- a/text-editor/README.md
+++ b/text-editor/README.md
@@ -7,9 +7,9 @@ A non-trivial sample with basic features of a code editor, like language detecti
 
 ## APIs
 
-* [chrome.fileSystem](http://developer.chrome.com/trunk/apps/fileSystem.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [chrome.fileSystem](http://developer.chrome.com/apps/fileSystem.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/twitter-webview-client/README.md
+++ b/twitter-webview-client/README.md
@@ -8,8 +8,8 @@ This is a very simple sample of how you can embed an existing web application in
 ## APIs
 
 * [webview](http://developer.chrome.com/apps/webview_tag.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/udp/README.md
+++ b/udp/README.md
@@ -29,9 +29,9 @@ In the `server` directory, you will find a Node echo server that intentionally d
 
 ## APIs
 
-* [UDP Network](http://developer.chrome.com/trunk/apps/app_network.html#udp)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [UDP Network](http://developer.chrome.com/apps/app_network.html#udp)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/udp/assets/screenshot_1280_800.png)

--- a/usb-label-printer/main.js
+++ b/usb-label-printer/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/experimental.app.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/experimental.app.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function(data) {
   // App Launched

--- a/usb/knob/README.md
+++ b/usb/knob/README.md
@@ -7,9 +7,9 @@ This demo interfaces with a [Griffin PowerMate](http://en.wikipedia.org/wiki/Gri
 
 ## APIs
 
-* [USB raw access](http://developer.chrome.com/trunk/apps/app_hardware.html#usb)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [USB raw access](http://developer.chrome.com/apps/app_hardware.html#usb)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/usb/knob/assets/screenshot_1280_800.png)

--- a/weather/README.md
+++ b/weather/README.md
@@ -12,10 +12,10 @@ that the user has chosen
 
 ## Resources
 
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
-* [Storage](http://developer.chrome.com/trunk/apps/storage.html)
-* [Geolocation](http://developer.chrome.com/trunk/apps/manifest.html#permissions)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
+* [Storage](http://developer.chrome.com/apps/storage.html)
+* [Geolocation](http://developer.chrome.com/apps/manifest.html#permissions)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/weather/assets/screenshot_1280_800.png)

--- a/webgl-pointer-lock/README.md
+++ b/webgl-pointer-lock/README.md
@@ -14,8 +14,8 @@ This sample uses the frameless window:
 
 ## APIs
 
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
 * [Pointer Lock](http://www.w3.org/TR/pointerlock/)
 
 ## External libs

--- a/webgl-pointer-lock/main.js
+++ b/webgl-pointer-lock/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/app.runtime.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.runtime.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html',

--- a/webserver/main.js
+++ b/webserver/main.js
@@ -1,8 +1,8 @@
 /**
  * Listens for the app launching then creates the window
  *
- * @see http://developer.chrome.com/trunk/apps/experimental.app.html
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/experimental.app.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 chrome.app.runtime.onLaunched.addListener(function(intentData) {
   chrome.app.window.create('index.html', {

--- a/websocket-server/README.md
+++ b/websocket-server/README.md
@@ -7,7 +7,7 @@ An example Http and WebSocket server implementation with a sample app which serv
 
 ## APIs
 
-* [chrome.socket](http://developer.chrome.com/trunk/apps/socket.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [chrome.socket](http://developer.chrome.com/apps/socket.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 

--- a/webview/README.md
+++ b/webview/README.md
@@ -8,8 +8,8 @@ Sample to explore some of the APIs in the webview tag.
 ## APIs
 
 * [webview](http://developer.chrome.com/apps/webview_tag.html)
-* [Runtime](http://developer.chrome.com/trunk/apps/app.runtime.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Runtime](http://developer.chrome.com/apps/app.runtime.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
 
      
 ## Screenshot

--- a/window-state/README.md
+++ b/window-state/README.md
@@ -9,7 +9,7 @@ and hidden states. Includes HTML5 requestFullscreen and app.window.fullscreen().
 ## Resources
 
 * [Fullscreen Specification](http://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html)
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/window-state/assets/screenshot_1280_800.png)

--- a/windows/README.md
+++ b/windows/README.md
@@ -3,13 +3,13 @@
 
 # Copycat Window
 
-Sample that shows how to use the [window API](http://developer.chrome.com/trunk/apps/app.window.html) to create a window with a custom frame and manipulate its properties.
+Sample that shows how to use the [window API](http://developer.chrome.com/apps/app.window.html) to create a window with a custom frame and manipulate its properties.
 
 The app creates two windows, an "original" window and a "copycat" window. The copycat window mimics the position and minimize state of the original window, but it displays itself in an inverted fashion.
 
 ## APIs
 
-* [Window](http://developer.chrome.com/trunk/apps/app.window.html)
+* [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/windows/assets/screenshot_1280_800.png)

--- a/windows/main.js
+++ b/windows/main.js
@@ -15,7 +15,7 @@ function reset() {
 
 /**
  * Initialise and launch the windows
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 function launch() {
 
@@ -82,7 +82,7 @@ function launch() {
 
 /**
  * Minimises both the original and copycat windows
- * @see http://developer.chrome.com/trunk/apps/app.window.html
+ * @see http://developer.chrome.com/apps/app.window.html
  */
 function minimizeAll() {
 
@@ -95,5 +95,5 @@ function minimizeAll() {
   setTimeout(reset, 2000);
 }
 
-// @see http://developer.chrome.com/trunk/apps/app.runtime.html
+// @see http://developer.chrome.com/apps/app.runtime.html
 chrome.app.runtime.onLaunched.addListener(launch);


### PR DESCRIPTION
I just ran the line below to remove all references to trunk/ which has been deprecated.
`sed -i 's/developer.chrome.com\/trunk/developer.chrome.com/g' $(git ls-files)`
