### PR TITLE
Remove "commands" from the manifest for now

### DIFF
--- a/url-handler/manifest.json
+++ b/url-handler/manifest.json
@@ -30,14 +30,5 @@
         "*://en.m.wikipedia.org/wiki/*"
       ]
     }
-  },
-
-  "command": {
-    "close": {
-      "suggested_key": {
-        "default": "Ctrl+W"
-      },
-      "description": "Close the app"
-    }
   }
 }


### PR DESCRIPTION
chrome.commands has landed only recently (currently in dev at best), so having it in an app sample can result in warnings for some users trying out the sample.

Also, there was a typo: "commands" was typed in as "command".
