### PR TITLE
Add http: method for API docs link

### DIFF
--- a/identity/index.html
+++ b/identity/index.html
@@ -11,7 +11,7 @@
       <h1>Identity API</h1>
       <div class="links">
         Learn more:
-          <a target="_blank" href="developer.chrome.com/apps/app_identity.html">API docs</a>
+          <a target="_blank" href="http://developer.chrome.com/apps/app_identity.html">API docs</a>
           <a id="_open_snippets" href="#">Source</a>
       </div>
       <hr>


### PR DESCRIPTION
Without the method the link does not work (with Win7 Chrome).
