### PR TITLE
Remove controls for modifying size constraints in the Window State sample app

### DIFF
--- a/window-state/window.html
+++ b/window-state/window.html
@@ -34,16 +34,6 @@
       <input type="number" class="size" id="moveWindowTop" step=1 />
       Width, Height: <input type="number" class="size" id="resizeWindowWidth" step=1 />
       <input type="number" class="size" id="resizeWindowHeight" step=1 />
-      <br>
-      <button id="setWindowMinWidth">Set Min Width</button>:
-      <input type="number" class="size" id="windowMinWidth" step=1 />,
-      <button id="setWindowMaxWidth">Set Max Width</button>:
-      <input type="number" class="size" id="windowMaxWidth" step=1 />
-      <br>
-      <button id="setWindowMinHeight">Set Min Height</button>:
-      <input type="number" class="size" id="windowMinHeight" step=1 />,
-      <button id="setWindowMaxHeight">Set Max Height</button>:
-      <input type="number" class="size" id="windowMaxHeight" step=1 />
     </p>
 
     <p><b>Create</b> a new window:<br>

--- a/window-state/window.js
+++ b/window-state/window.js
@@ -158,42 +158,6 @@ $('#setbounds').onclick = function(e) {
     $('#delay-slider').value);
 };
 
-$('#setWindowMinWidth').onclick = function(e) {
-  var value = parseInt($('#windowMinWidth').value);
-  setTimeout(
-    function() {
-      chrome.app.window.current().setMinWidth(value);
-    },
-    $('#delay-slider').value);
-};
-
-$('#setWindowMaxWidth').onclick = function(e) {
-  var value = parseInt($('#windowMaxWidth').value);
-  setTimeout(
-    function() {
-      chrome.app.window.current().setMaxWidth(value);
-    },
-    $('#delay-slider').value);
-};
-
-$('#setWindowMinHeight').onclick = function(e) {
-  var value = parseInt($('#windowMinHeight').value);
-  setTimeout(
-    function() {
-      chrome.app.window.current().setMinHeight(value);
-    },
-    $('#delay-slider').value);
-};
-
-$('#setWindowMaxHeight').onclick = function(e) {
-  var value = parseInt($('#windowMaxHeight').value);
-  setTimeout(
-    function() {
-      chrome.app.window.current().setMaxHeight(value);
-    },
-    $('#delay-slider').value);
-};
-
 var updateDelaySiderText = function updateDelaySiderText() {
   $('#delay-label').innerText = $('#delay-slider').value / 1000 + " seconds.";
 }
@@ -257,11 +221,6 @@ function updateCurrentStateReadout() {
   $('#moveWindowTop').placeholder = chrome.app.window.current().getBounds().top;
   $('#resizeWindowWidth').placeholder = chrome.app.window.current().getBounds().width;
   $('#resizeWindowHeight').placeholder = chrome.app.window.current().getBounds().height;
-
-  $('#windowMinWidth').placeholder = chrome.app.window.current().getMinWidth();
-  $('#windowMaxWidth').placeholder = chrome.app.window.current().getMaxWidth();
-  $('#windowMinHeight').placeholder = chrome.app.window.current().getMinHeight();
-  $('#windowMaxHeight').placeholder = chrome.app.window.current().getMaxHeight();
 
   $('#newWindowWidthMin').placeholder = chrome.app.window.current().getBounds().width;
   $('#newWindowWidthMax').placeholder = chrome.app.window.current().getBounds().width;


### PR DESCRIPTION
The API for setting the min/max size constraints after window creation were still in Dev channel and replaced by a newer app window bounds API. The controls for modifying the size constraints have been temporarily removed.
