### PR TITLE
Window State Sample: Added frame color option for new window.

### DIFF
--- a/window-state/window.html
+++ b/window-state/window.html
@@ -62,6 +62,11 @@
       <button id="newWindowFullscreen">Fullscreen</button>
       <button id="newWindowMaximized">Maximized</button>
       <button id="newWindowMinimized">Minimized</button>
+      <br>
+      Color:
+      <label><input type="radio" name="newWindowColorEnabled" value="native" checked/>Native-themed</label>
+      <label><input type="radio" name="newWindowColorEnabled" value="colored" id="newWindowColorEnabledTrue" />
+        <input type="color" id="newWindowColor" value="#ffffff" /></label>
     </p>
 
     <p>Current window state:

--- a/window-state/window.js
+++ b/window-state/window.js
@@ -25,6 +25,13 @@ function setIfANumber(dictionary, field, number) {
   dictionary[field] = number
 }
 
+var regexColor = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+function setIfAColor(dictionary, field, color) {
+  if (!regexColor.test(color))
+    return;
+  dictionary[field] = color;
+}
+
 function createNewWindow(optionsDictionary) {
   optionsDictionary = optionsDictionary || {};
 
@@ -62,6 +69,14 @@ function createNewWindow(optionsDictionary) {
   optionsDictionary.bounds.top = bounds.top;
   optionsDictionary.bounds.width = bounds.width;
   optionsDictionary.bounds.height = bounds.height;
+
+  // Set frameOptions.
+  var frameOptions = {};
+  if ($('#newWindowColorEnabledTrue').checked) {
+    setIfAColor(frameOptions, 'color', $('#newWindowColor').value);
+  }
+  if (Object.keys(frameOptions).length > 0)
+    optionsDictionary.frameOptions = frameOptions;
 
   chrome.app.window.create('window.html', optionsDictionary, callback);
 };
@@ -164,6 +179,10 @@ var updateDelaySiderText = function updateDelaySiderText() {
 
 $('#delay-slider').onchange = updateDelaySiderText;
 updateDelaySiderText();  // Initial text update.
+
+$('#newWindowColor').onclick = function(e) {
+  $('#newWindowColorEnabledTrue').checked = true;
+};
 
 $('#newWindowNormal').onclick = function(e) {
   createNewWindow();


### PR DESCRIPTION
Allows the use of the new frameOptions: color API, which can be used to
either ask for a native-themed window or a colored title bar of the
user's choice.
