### PR TITLE
Update gapi-chrome-apps.js

### DIFF
--- a/gapi-chrome-apps-lib/gapi-chrome-apps.js
+++ b/gapi-chrome-apps-lib/gapi-chrome-apps.js
@@ -119,9 +119,13 @@
         }
       };
 
-      var jsonResp = JSON.parse(this.response);
       var rawResp = JSON.stringify(rawResponseObject);
-      args.callback(jsonResp, rawResp);
+      if (this.response) {
+        var jsonResp = JSON.parse(this.response);
+        args.callback(jsonResp, rawResp);
+      } else {
+        args.callback(null, rawResp);
+      }
     };
   };
 


### PR DESCRIPTION
JSON.parse("") throws an error, however some Google APIs return a blank response for success.  Ran into this when doing Calendar event delete (https://developers.google.com/google-apps/calendar/v3/reference/events/delete) which returns no response for successful delete.

Propose returning null for such a response.
