### PR TITLE
Update gapi-chrome-apps.js

### DIFF
--- a/gapi-chrome-apps-lib/gapi-chrome-apps.js
+++ b/gapi-chrome-apps-lib/gapi-chrome-apps.js
@@ -55,6 +55,10 @@
 
     var details = {};
     details.interactive = params.immediate === false || false;
+    if (params.accountHint) {
+      // Indicate preferred account when on Android
+      detals.accountHint = params.accountHint;
+    }
     console.assert(!params.response_type || params.response_type == 'token');
 
     var callbackWrapper = function (getAuthTokenCallbackParam) {


### PR DESCRIPTION
When using this with a cca-built app for Chrome/Android, the account-chooser window appears on every auth on Android.  The only way to prevent this is to provide an accountHint, which is an email address.  This allows truly 'silent' login on Android, whereas the current implementation only avoids the permissions dialog but not the account chooser.
