### PR TITLE
rich-notifications: Remove Mac from the warning

### DIFF
--- a/rich-notifications/README.md
+++ b/rich-notifications/README.md
@@ -4,11 +4,11 @@
 # Rich notifications
 
 This sample shows how to use the "templated" notifications API,
-aka Rich Notifications, which allows an app to show feature-rich notifications 
+aka Rich Notifications, which allows an app to show feature-rich notifications
 in the system tray. This API is still in experimental state.
 
 
-> WARNING: currently this API only works on ChromeOS and Windows. Linux and Mac should fail gracefully by displaying normal HTML5 notifications, but some info might not be presented on these platforms.
+> WARNING: currently this API only works on ChromeOS and Windows. Linux should fail gracefully by displaying normal HTML5 notifications, but some info might not be presented on these platforms.
 
 ## Resources
 
@@ -17,4 +17,3 @@ in the system tray. This API is still in experimental state.
 ## Screenshot
 
 ![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/rich-notifications/assets/screenshot_1280_800.png)
-


### PR DESCRIPTION
Testing this on Chrome 35 on MacOS 10.9 everything is working as advertised.

![screen shot 2014-06-27 at 11 01 45 am](https://cloud.githubusercontent.com/assets/9491/3407927/80109026-fdbc-11e3-8208-4a5851f5da5b.png)
