### PR TITLE
Change event handler registration

### DIFF
--- a/keyboard-handler/window.js
+++ b/keyboard-handler/window.js
@@ -104,8 +104,8 @@ function MonitorFocus()
   logEvent("focus");
 }
 
-document.onkeydown = MonitorKeyDown;
-document.onkeyup = MonitorKeyUp;
-document.onkeypress = MonitorKeyPress;
+document.addEventListener('keydown', MonitorKeyDown, false)
+document.addEventListener('keyup', MonitorKeyUp, false)
+document.addEventListener('keypress', MonitorKeyPress, false)
 document.body.onblur = MonitorBlur;
 document.body.onfocus = MonitorFocus;


### PR DESCRIPTION
Change event handler registration to addEventListener instead of using deprecated overriding of onKeydown, etc. This also fixes the issues where the app was not getting keypress callbacks.
