### PR TITLE
Removed LICENSE section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,21 +173,3 @@ href="https://github.com/MobileChromeApps/mobile-chrome-apps/blob/master/README.
 
 ## Google APIs client library for Chrome Apps:
 * [gapi-chrome-apps-lib](https://github.com/GoogleChrome/chrome-app-samples/tree/master/gapi-chrome-apps-lib)
-
-
-# LICENSE
-
-Copyright 2013 Google Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-


### PR DESCRIPTION
Since the [LICENSE](https://github.com/GoogleChrome/chrome-app-samples/blob/master/LICENSE) file already exists, we can clean the README file and remove the duplicated section.
