### PR TITLE
[blink1] Used filters in chrome.hid.getDevices

### DIFF
--- a/blink1/color-picker.js
+++ b/blink1/color-picker.js
@@ -32,7 +32,7 @@
 
   function enumerateDevices() {
     chrome.hid.getDevices(
-        { "vendorId": 10168, "productId": 493 },
+        { "filters": [ { "vendorId": 10168, "productId": 493 } ] },
         onDevicesEnumerated);
   };
 

--- a/blink1/manifest.json
+++ b/blink1/manifest.json
@@ -2,7 +2,7 @@
   "name": "blink(1)",
   "manifest_version": 2,
   "version": "0.1",
-  "minimum_chrome_version": "39.0.2129.0",
+  "minimum_chrome_version": "39.0.2140.0",
   "app": {
     "background": {
       "scripts": [ "main.js" ]


### PR DESCRIPTION
Since the `vendorId` and `productId` properties of `GetDevicesOptions` are deprecated, I suggest we use the new `filters` in the blink1 sample app.

https://codereview.chromium.org/514923002

TBR=@reillyeon

![image](https://cloud.githubusercontent.com/assets/634478/4087711/7316d322-2f52-11e4-910d-787b0111801d.png)
