### PR TITLE
Removed deprecated CreateWindowOptions

### DIFF
--- a/appengine_channelapi/app/main.js
+++ b/appengine_channelapi/app/main.js
@@ -7,7 +7,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
   	id: "appEngineSampleID",
-    bounds: {
+    innerBounds: {
       width: 500,
       height: 300
     }

--- a/appsquare/background.js
+++ b/appsquare/background.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('main.html', {
   	id: "appSquareID",
-    bounds: {
+    innerBounds: {
       width: 300,
       height: 600
     }

--- a/calculator/main.js
+++ b/calculator/main.js
@@ -13,11 +13,11 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('calculator.html', {
     id: "calcWinID",
-    bounds: {
+    innerBounds: {
       width: 244,
-      height: 380
-    },
-    minWidth: 244,
-    minHeight: 380
+      height: 380,
+      minWidth: 244,
+      minHeight: 380
+    }
   });
 });

--- a/camera-capture/background.js
+++ b/camera-capture/background.js
@@ -7,7 +7,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
   	id: "camCaptureID",
-    bounds: {
+    innerBounds: {
       width: 700,
       height: 600
     }

--- a/clock/main.js
+++ b/clock/main.js
@@ -13,7 +13,7 @@
  chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
   	id: "clockWinID",
-    bounds: {
+    innerBounds: {
       height: 550,
       width: 800,
       top: 100

--- a/context-menu/main.js
+++ b/context-menu/main.js
@@ -1,6 +1,6 @@
 chrome.app.runtime.onLaunched.addListener(function() {
-  chrome.app.window.create('a.html', {bounds:{top: 0, left: 0, width: 300, height: 300}});
-  chrome.app.window.create('b.html', {bounds:{top: 0, left: 310, width: 300, height: 300}});
+  chrome.app.window.create('a.html', {innerBounds:{top: 0, left: 0, width: 300, height: 300}});
+  chrome.app.window.create('b.html', {innerBounds:{top: 0, left: 310, width: 300, height: 300}});
 });
 
 chrome.runtime.onInstalled.addListener(function() {
@@ -19,7 +19,7 @@ chrome.runtime.onInstalled.addListener(function() {
 
 chrome.contextMenus.onClicked.addListener(function(itemData) {
 	if (itemData.menuItemId == "launcher1")
-		chrome.app.window.create('a.html', {bounds:{top: 0, left: 0, width: 300, height: 300}});
+		chrome.app.window.create('a.html', {innerBounds:{top: 0, left: 0, width: 300, height: 300}});
 	if (itemData.menuItemId == "launcher2")
-		chrome.app.window.create('b.html', {bounds:{top: 0, left: 310, width: 300, height: 300}});
+		chrome.app.window.create('b.html', {innerBounds:{top: 0, left: 310, width: 300, height: 300}});
 });

--- a/dart/js/main.js
+++ b/dart/js/main.js
@@ -6,5 +6,5 @@
  */
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('clock.html',
-    {id: 'clock', bounds: {width: 800, height: 550}});
+    {id: 'clock', innerBounds: {width: 800, height: 550}});
 });

--- a/desktop-capture/background.js
+++ b/desktop-capture/background.js
@@ -7,7 +7,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
     id: "desktopCaptureID",
-    bounds: {
+    innerBounds: {
       width: 700,
       height: 600
     }

--- a/dialog-element/main.js
+++ b/dialog-element/main.js
@@ -13,7 +13,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
 
   chrome.app.window.create('index.html', {
     id: "window1",
-    bounds: {
+    outerBounds: {
       width: width,
       height: height,
       left: Math.round((screenWidth-width)/2),

--- a/diff/js/background.js
+++ b/diff/js/background.js
@@ -7,7 +7,7 @@
 function onLaunched(launchData) {
   chrome.app.window.create('main.html', {
   	id: "diffWinID",
-    bounds: {
+    innerBounds: {
       width: 1270,
       height: 800
     }

--- a/dojo/build.sh
+++ b/dojo/build.sh
@@ -19,7 +19,7 @@ function _dojo_launch(app) {
 
 function _dojo_readme(file) {
   chrome.app.window.create(file,
-    {bounds: {width: 500, height: 700, left: 602}});
+    {innerBounds: {width: 500, height: 700, left: 602}});
 }
 function _dojo_source(app) {
   window.open("https://github.com/GoogleChrome/chrome-app-samples/tree/master/"+app);
@@ -53,7 +53,7 @@ function writeJS_launch() {
 
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
-    bounds: {
+    innerBounds: {
       width: 600,
       height: 800
     }

--- a/filesystem-access/background.js
+++ b/filesystem-access/background.js
@@ -1,5 +1,5 @@
 chrome.app.runtime.onLaunched.addListener(function(launchData) {
-  chrome.app.window.create('index.html', {id:"fileWin", bounds: {width: 800, height: 500}}, function(win) {
+  chrome.app.window.create('index.html', {id:"fileWin", innerBounds: {width: 800, height: 500}}, function(win) {
     win.contentWindow.launchData = launchData;
   });
 });

--- a/frameless-window/background.js
+++ b/frameless-window/background.js
@@ -2,14 +2,13 @@ chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create("frameless_window.html",
     {  frame: "none",
        id: "framelessWinID",
-       bounds: {
+       innerBounds: {
          width: 360,
          height: 300,
-         left: 600
-       },
-       minWidth: 220,
-       minHeight: 220
+         left: 600,
+         minWidth: 220,
+         minHeight: 220
+      }
     }
   );
 });
-

--- a/gdrive/js/background.js
+++ b/gdrive/js/background.js
@@ -1,12 +1,12 @@
 chrome.app.runtime.onLaunched.addListener(function(launchData) {
   chrome.app.window.create('../main.html', {
     id: "GDriveExample",
-    bounds: {
+    innerBounds: {
       width: 500,
-      height: 600
+      height: 600,
+      minWidth: 500,
+      minHeight: 600
     },
-    minWidth: 500,
-    minHeight: 600,
     frame: 'none'
   });
 });

--- a/github-auth/main.js
+++ b/github-auth/main.js
@@ -1,6 +1,6 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', 
-    { "bounds": { "width": 400, "height": 300 },
+    { "innerBounds": { "width": 400, "height": 300 },
       "id": "index"
     });
 });

--- a/hello-world-sync/main.js
+++ b/hello-world-sync/main.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
   	id: "helloWorldSyncID",
-    bounds: {
+    innerBounds: {
       width: 500,
       height: 415
     }

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -17,7 +17,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
 
   chrome.app.window.create('index.html', {
     id: "helloWorldID",
-    bounds: {
+    outerBounds: {
       width: width,
       height: height,
       left: Math.round((screenWidth-width)/2),

--- a/hello-world/main.js
+++ b/hello-world/main.js
@@ -13,7 +13,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
 
   chrome.app.window.create('index.html', {
     id: "helloWorldID",
-    bounds: {
+    outerBounds: {
       width: width,
       height: height,
       left: Math.round((screenWidth-width)/2),

--- a/identity/main.js
+++ b/identity/main.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html',
     { "id": "identitywin",
-      "bounds": {
+      "innerBounds": {
         "width": 454,
         "height": 540
       }

--- a/identity/sample_support/sample_support.js
+++ b/identity/sample_support/sample_support.js
@@ -58,7 +58,7 @@
         e.preventDefault();
         chrome.app.window.create('sample_support/show_snippets.html',
           { "id": SampleSupport.SNIPPET_WIN_ID,
-            "bounds": {
+            "innerBounds": {
               "width": 760,
               "height": 760
             }

--- a/instagram-auth/main.js
+++ b/instagram-auth/main.js
@@ -7,7 +7,7 @@
 chrome.app.runtime.onLaunched.addListener(function(intentData) {
     chrome.app.window.create('index.html', {
     	id: "instagramAuthWinID",
-        bounds: {
+        innerBounds: {
             width: 500,
             height: 309
         }

--- a/io2012-presentation/js/main.js
+++ b/io2012-presentation/js/main.js
@@ -14,10 +14,12 @@ chrome.app.runtime.onLaunched.addListener(function() {
 
   chrome.app.window.create('presentation.html?presentme=true', {
       frame: 'chrome',
-      left: left, top: top,
-      width: PRESENTATION_WIDTH, height: PRESENTATION_HEIGHT,
-      minWidth: PRESENTATION_WIDTH, minHeight: PRESENTATION_HEIGHT,
-      maxWidth: PRESENTATION_WIDTH, maxHeight: PRESENTATION_HEIGHT
+      innerBounds: {
+        left: left, top: top,
+        width: PRESENTATION_WIDTH, height: PRESENTATION_HEIGHT,
+        minWidth: PRESENTATION_WIDTH, minHeight: PRESENTATION_HEIGHT,
+        maxWidth: PRESENTATION_WIDTH, maxHeight: PRESENTATION_HEIGHT
+      }
   }, function(w) {
     presentationWindow = w;
   });

--- a/ioio/background.js
+++ b/ioio/background.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
   	id: "window1",
-    bounds: {
+    innerBounds: {
       width: 640,
       height: 480
     }

--- a/keyboard-handler/background.js
+++ b/keyboard-handler/background.js
@@ -12,6 +12,6 @@ chrome.app.runtime.onLaunched.addListener(function() {
 
   chrome.app.window.create('window.html', {
     id: "keyboardWinID",
-    bounds: b
+    outerBounds: b
   });
 });

--- a/manga-cam/background.js
+++ b/manga-cam/background.js
@@ -16,8 +16,10 @@ chrome.app.runtime.onLaunched.addListener(function () {
     resizable: false,
     frame: 'none',
     id: "index",
-    width: 640,
-    height: 635
+    innerBounds: {
+      width: 640,
+      height: 635
+    }
   }, function(newWindow) {
     if (newWindow.contentWindow != wind) {
       newWindow.contentWindow.onload = onWindowLoaded;

--- a/mdns-browser/background.js
+++ b/mdns-browser/background.js
@@ -2,11 +2,11 @@ chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('main.html', {
     id: 'mainWindow',
     frame: 'none',
-    bounds: {
+    innerBounds: {
       width: 440,
       height: 440,
-    },
-    minWidth: 440,
-    minHeight: 200,
+      minWidth: 440,
+      minHeight: 200
+    }
   });
 });

--- a/media-gallery/runtime.js
+++ b/media-gallery/runtime.js
@@ -3,7 +3,7 @@
 
 chrome.app.runtime.onLaunched.addListener(function(data) {
     chrome.app.window.create('page.html', 
-    	{bounds: {width:900, height:600}, minWidth:900, maxWidth: 900, minHeight:600, maxHeight: 600, id:"MGExp"}, 
+    	{innerBounds: {width:900, height:600, minWidth:900, maxWidth: 900, minHeight:600, maxHeight: 600}, id:"MGExp"}, 
     	function(app_win) {
     		app_win.contentWindow.__MGA__bRestart = false;
     	}
@@ -13,7 +13,7 @@ chrome.app.runtime.onLaunched.addListener(function(data) {
 
 chrome.app.runtime.onRestarted.addListener(function() {
     chrome.app.window.create('page.html', 
-    	{bounds: {width:900, height:600}, minWidth:900, maxWidth: 900, minHeight:600, maxHeight: 600, id:"MGExp"}, 
+    	{innerBounds: {width:900, height:600, minWidth:900, maxWidth: 900, minHeight:600, maxHeight: 600}, id:"MGExp"}, 
     	function(app_win) {
     		app_win.contentWindow.__MGA__bRestart = true;
     	}

--- a/messaging/app1/main.js
+++ b/messaging/app1/main.js
@@ -8,7 +8,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html',
     {
     	id: "messagingEx1ID",
-    	bounds: {width: 800, height: 500}
+    	innerBounds: {width: 800, height: 500}
     });
 });
 //function addExternalMessageListener

--- a/messaging/app2/main.js
+++ b/messaging/app2/main.js
@@ -8,7 +8,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html',
     {
     	id: "messagingEx2ID",
-    	bounds: {width: 800, height: 500}
+    	innerBounds: {width: 800, height: 500}
     });
 });
 //function addExternalMessageListener

--- a/mini-code-edit/background.js
+++ b/mini-code-edit/background.js
@@ -2,7 +2,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
   // width 640 for font size 12
   //       720 for font size 14
   chrome.app.window.create('main.html', {
-    frame: 'chrome', id: "codewin", bounds: { width: 720, height: 400}, minWidth:720, minHeight: 400
+    frame: 'chrome', id: "codewin", innerBounds: { width: 720, height: 400, minWidth:720, minHeight: 400 }
   });
 });
 
@@ -15,7 +15,7 @@ chrome.commands.onCommand.addListener(function(command) {
 
    if (command == "cmdNew") {
      chrome.app.window.create('main.html', {
-       frame: 'chrome', id: "codewin", bounds: { width: 720, height: 400}, minWidth:720, minHeight: 400
+       frame: 'chrome', id: "codewin", innerBounds: { width: 720, height: 400, minWidth:720, minHeight: 400 }
      });
    }
 });

--- a/mini-code-edit/editor.js
+++ b/mini-code-edit/editor.js
@@ -124,7 +124,7 @@ function handleNewButton() {
     editor.setValue("");
   } else {
     chrome.app.window.create('main.html', {
-      frame: 'chrome', id: "codewin", bounds: { width: 720, height: 400}
+      frame: 'chrome', id: "codewin", innerBounds: { width: 720, height: 400}
     });
   }
 }

--- a/multicast/background.js
+++ b/multicast/background.js
@@ -39,14 +39,14 @@ function createMainWindow() {
   chrome.app.window.create('index.html', {
     singleton: true,
     id: 'main-window',
-    minWidth: 400,
-    minHeight: 275,
     frame: 'none',
-    bounds: {
+    innerBounds: {
       left: 100,
       top: 100,
       width: 650,
-      height: 520
+      height: 520,
+      minWidth: 400,
+      minHeight: 275
     },
     hidden: true
   }, onInitWindow);

--- a/one-time-payment/main.js
+++ b/one-time-payment/main.js
@@ -1,11 +1,11 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
     "id": "One-Time-Payment-Demo",
-    "bounds": {
+    "innerBounds": {
       "width": 640,
-      "height": 310
-    },
-    "minWidth": 640,
-    "minHeight": 310
+      "height": 310,
+      "minWidth": 640,
+      "minHeight": 310
+    }
   });
 });

--- a/optional-permissions/main.js
+++ b/optional-permissions/main.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('permissions.html', {
     id: 'permissions',
-    bounds: {
+    innerBounds: {
       width: 640,
       height: 480
     }

--- a/parrot-ar-drone/main.js
+++ b/parrot-ar-drone/main.js
@@ -13,7 +13,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
 
   chrome.app.window.create('index.html', {
     id: "mainwin", 
-    bounds: {
+    innerBounds: {
       width: 565,
       height: 400
     }

--- a/restarted-demo/background.js
+++ b/restarted-demo/background.js
@@ -94,7 +94,7 @@ Counter.prototype.close = function() {
 function runApp(counter) {
   chrome.app.window.create('main.html', {
     id: counter.id + '',
-    bounds: {
+    innerBounds: {
       width: 800,
       height: 600
     }

--- a/rich-notifications/app.js
+++ b/rich-notifications/app.js
@@ -1,6 +1,6 @@
 chrome.app.runtime.onLaunched.addListener(function () {
   chrome.app.window.create("window.html", {
     id: "mainwin",
-    bounds: {width:600, height:400}
+    innerBounds: {width:600, height:400}
   });
 });

--- a/sandbox/main.js
+++ b/sandbox/main.js
@@ -8,6 +8,6 @@ chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('mainpage.html',
     {
     	id: "mainwin",
-    	bounds: {width: 500, height: 309}
+    	innerBounds: {width: 500, height: 309}
     });
 });

--- a/sandboxed-content/main.js
+++ b/sandboxed-content/main.js
@@ -8,6 +8,6 @@ chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('main.html',
     {
     	id: "mainwin",
-    	bounds: {width: 400, height: 350}
+    	innerBounds: {width: 400, height: 350}
     });
 });

--- a/serial-control-signals/background.js
+++ b/serial-control-signals/background.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('main.html', {
     id: "mainwin",
-    bounds: {
+    innerBounds: {
       top: 0,
       left: 0,
       width: 640,

--- a/serial/adkjs/app/js/background.js
+++ b/serial/adkjs/app/js/background.js
@@ -3,6 +3,6 @@ chrome.app.runtime.onLaunched.addListener(function() {
      {
      	frame: 'custom', 
      	id: "mainwin",
-     	bounds: {width: 343, height: 600}
+     	innerBounds: {width: 343, height: 600}
      });
 });

--- a/serial/espruino/launch.js
+++ b/serial/espruino/launch.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
 	id: "mainwin",
-    bounds: {
+    innerBounds: {
       width: 320,
       height: 240
     }

--- a/serial/ledtoggle/launch.js
+++ b/serial/ledtoggle/launch.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
 	id: "mainwin",
-    bounds: {
+    innerBounds: {
       width: 320,
       height: 240
     }

--- a/servo/background.js
+++ b/servo/background.js
@@ -1,6 +1,6 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('main.html', {
-    bounds: {
+    innerBounds: {
       top: 0,
       left: 0,
       width: 640,

--- a/storage/background.js
+++ b/storage/background.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('main.html', {
 	id: "mainwin",
-    bounds: {
+    innerBounds: {
       'width': 400,
       'height': 500
     }

--- a/syncfs-editor/js/background.js
+++ b/syncfs-editor/js/background.js
@@ -3,7 +3,6 @@ chrome.app.runtime.onLaunched.addListener(function (arg) {
     'main.html',
     { 
     	id: "mainwin",
-    	bounds: { width:780, height:490}, 
-    	type:"shell" 
+    	innerBounds: { width:780, height:490}
     });
 });

--- a/systemInfo/main.js
+++ b/systemInfo/main.js
@@ -13,7 +13,7 @@
  chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
 	id: "mainwin",
-    bounds: {
+    innerBounds: {
       height: 550,
       width: 800
     }

--- a/tasks/main.js
+++ b/tasks/main.js
@@ -1,6 +1,6 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
       id: "mainwin",
-      "bounds": { "width": 1024, "height": 768 }
+      "innerBounds": { "width": 1024, "height": 768 }
   });
 });

--- a/tcpserver/commands/BrowserCommands.js
+++ b/tcpserver/commands/BrowserCommands.js
@@ -68,7 +68,7 @@ Commands.addCommand("echo",
 Commands.addCommand("open", 
   "Open the given URL", 
   function(args) {
-    chrome.app.window.create('commands/webview.html', {bounds: {width: 600, height: 400}},
+    chrome.app.window.create('commands/webview.html', {innerBounds: {width: 600, height: 400}},
       function(w) {
         w.contentWindow.addEventListener("DOMContentLoaded", function() {
           var doc=w.contentWindow.document;

--- a/tcpserver/main.js
+++ b/tcpserver/main.js
@@ -13,7 +13,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
 		commandWindow.focus();
 	} else {
 		chrome.app.window.create('index.html',
-			{id: "mainwin", bounds: {width: 500, height: 309, left: 0}},
+			{id: "mainwin", innerBounds: {width: 500, height: 309, left: 0}},
 			function(w) {
 				commandWindow = w;
 			});

--- a/telnet/launch.js
+++ b/telnet/launch.js
@@ -7,7 +7,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('terminal.html', {
   	id: "mainwin",
-    bounds: {
+    innerBounds: {
       width: 880,
       height: 480
     }

--- a/todomvc/background.js
+++ b/todomvc/background.js
@@ -9,7 +9,7 @@ var dbName = 'todos-vanillajs';
 function launch() {
   chrome.app.window.create('index.html', {
     id: 'main',
-    bounds: { width: 620, height: 500 }
+    innerBounds: { width: 620, height: 500 }
   });
 }
 

--- a/tts/main.js
+++ b/tts/main.js
@@ -13,7 +13,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
 
   chrome.app.window.create('ttsdemo.html', {
     id: 'ttsID',
-    bounds: {
+    outerBounds: {
       width: width,
       height: height,
       left: Math.round((screenWidth-width)/2),

--- a/udp/main.js
+++ b/udp/main.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('echo_mco.html', {
   	id: "mainwin",
-    bounds: {
+    innerBounds: {
       width: 680,
       height: 480
     }

--- a/url-handler/main.js
+++ b/url-handler/main.js
@@ -44,7 +44,7 @@ AppWindow.prototype.createWindow_ = function(settings) {
     'main.html',
     {
       id: "mainwin",
-      bounds: { width: settings.width, height: settings.height },
+      innerBounds: { width: settings.width, height: settings.height },
       frame: 'chrome'
     },
     function(win) {
@@ -66,7 +66,7 @@ AppWindow.prototype.onLoad_ = function() {
 // Update this window's cached bounds and, if the window has been resized as
 // opposed to just moved, also update the global app's default window size.
 AppWindow.prototype.onBoundsChanged_ = function() {
-  var bounds = this.win_.getBounds();
+  var bounds = this.win_.innerBounds;
   if (bounds.width !== this.bounds_.width ||
       bounds.height !== this.bounds_.height) {
       app.updateSettings_({ width: bounds.width, height: bounds.height });

--- a/usb-label-printer/main.js
+++ b/usb-label-printer/main.js
@@ -8,6 +8,6 @@ chrome.app.runtime.onLaunched.addListener(function(data) {
   // App Launched
   chrome.app.window.create('index.html',
     { id: 'main',
-      bounds: {width: 1030, height: 704}
+      innerBounds: {width: 1030, height: 704}
     });
 });

--- a/usb/knob/background.js
+++ b/usb/knob/background.js
@@ -1,6 +1,6 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('knob.html', {
-    bounds: {
+    innerBounds: {
       width: 400,
       height: 400
     },

--- a/weather/main.js
+++ b/weather/main.js
@@ -1,13 +1,10 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('weather.html', {
     id: 'weather',
-    bounds: {
+    innerBounds: {
       height: 450,
-      width: 300
+      width: 300,
     },
-    minHeight: 450,
-    minWidth: 300,
-    maxHeight: 450,
-    maxWidth: 300,
+    resizable: false
   });
 });

--- a/web-store/background.js
+++ b/web-store/background.js
@@ -3,6 +3,6 @@ chrome.app.runtime.onLaunched.addListener(function() {
     { 
       "id": "mainWindow",
       "resizable": false,
-      "bounds": { "width": 360, "height": 540 }
+      "innerBounds": { "width": 360, "height": 540 }
     });
 });

--- a/webgl-pointer-lock/README.md
+++ b/webgl-pointer-lock/README.md
@@ -9,7 +9,7 @@ This sample uses the frameless window:
 
     chrome.app.runtime.onLaunched.addListener(function() {
       chrome.app.window.create('index.html',
-        {frame: 'none', bounds: {width: 500, height: 400}});
+        {frame: 'none', innerBounds: {width: 500, height: 400}});
     });
 
 ## APIs

--- a/webgl-pointer-lock/main.js
+++ b/webgl-pointer-lock/main.js
@@ -9,6 +9,6 @@ chrome.app.runtime.onLaunched.addListener(function() {
     {
     	id: "mainwin",
     	frame:"none", 
-    	bounds: {width: 500, height: 400}
+    	innerBounds: {width: 500, height: 400}
     });
 });

--- a/webserver/main.js
+++ b/webserver/main.js
@@ -6,7 +6,7 @@
 chrome.app.runtime.onLaunched.addListener(function(intentData) {
   chrome.app.window.create('index.html', {
   	id: "mainwin",
-    bounds: {
+    innerBounds: {
       width: 500,
       height: 640
     }

--- a/websocket-server/background.js
+++ b/websocket-server/background.js
@@ -1,8 +1,10 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
-    width: 800,
-    height: 600,
-    minWidth: 200,
-    minHeight: 200,
+    innerBounds: {
+      width: 800,
+      height: 600,
+      minWidth: 200,
+      minHeight: 200,
+    }
   });
 });

--- a/webview-samples/browser/main.js
+++ b/webview-samples/browser/main.js
@@ -25,7 +25,7 @@ chrome.app.runtime.onRestarted.addListener(function() {
 function runApp() {
   chrome.app.window.create('browser.html', {
   	id: "browserWinID",
-    bounds: {
+    innerBounds: {
       'width': 1024,
       'height': 768
     }

--- a/webview-samples/webview/main.js
+++ b/webview-samples/webview/main.js
@@ -6,7 +6,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
     id: 'embedder',
-    bounds: {
+    innerBounds: {
       width: 1430,
       height: 870
     }

--- a/window-state/background.js
+++ b/window-state/background.js
@@ -1,7 +1,7 @@
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('window.html', {
   	id: "mainwin",
-    bounds: {
+    innerBounds: {
       width: 700,
       height: 600
     }

--- a/windows/main.js
+++ b/windows/main.js
@@ -25,15 +25,15 @@ function launch() {
   // create the original window
   chrome.app.window.create('original.html', {
       id: "mainwin",
-      bounds: {
+      innerBounds: {
         top: 128,
         left: 128,
         width: 300,
-        height: 300
+        height: 300,
+        minHeight: 300,
+        maxWidth: 500,
+        minWidth: 300
       },
-      minHeight: 300,
-      maxWidth: 500,
-      minWidth: 300,
       frame: 'none'
     },
 
@@ -45,15 +45,15 @@ function launch() {
 
       chrome.app.window.create('copycat.html', {
         id: "copywin",
-        bounds: {
+        innerBounds: {
           top: 128,
           left: 428 + 5,
           width: 300,
-          height: 300
+          height: 300,
+          minHeight: 300,
+          maxWidth: 500,
+          minWidth: 300
         },
-        minHeight: 300,
-        maxWidth: 500,
-        minWidth: 300,
         frame: 'none'
       },
 
@@ -68,9 +68,8 @@ function launch() {
         copycatWindow.onClosed.addListener(reset);
 
         originalWindow.onBoundsChanged.addListener(function() {
-          var bounds = originalWindow.getBounds();
-          bounds.left = bounds.left + bounds.width + 5;
-          copycatWindow.setBounds(bounds);
+          var bounds = originalWindow.outerBounds;
+          copycatWindow.outerBounds.left = bounds.left + bounds.width + 5;
         });
 
         copycatWindow.onRestored.addListener(function() {

--- a/zephyr_hxm/background.js
+++ b/zephyr_hxm/background.js
@@ -6,7 +6,7 @@ var HXM_PROFILE = {
 
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create('index.html', {
-    bounds: {
+    innerBounds: {
       width: 600,
       height: 350
     },


### PR DESCRIPTION
This replaces CreateWindowOptions `bounds`, `getBounds` and `setBounds` appropriately with `innerBounds` or `outerBounds`.
It also takes care of moving `width` and `height` set directly in CreateWindowOptions in a new `innerBounds` or `outerBounds` key.

See https://developer.chrome.com/apps/app_window for a full list of deprecated elements.

Note: the [Printing sample](https://github.com/beaufortfrancois/chrome-app-samples/tree/master/printing) needs more thoughts and will be committed in a separate PR.
