### PR TITLE
[mini-code-edit] Added back command Ctrl+Shift+1

### DIFF
--- a/mini-code-edit/manifest.json
+++ b/mini-code-edit/manifest.json
@@ -21,6 +21,15 @@
     "32":  "img/32x32/file_edit.png",
     "64":  "img/64x64/file_edit.png",
     "128": "img/128x128/file_edit.png"
-  }
+  },
 
+  "commands" : {
+    "cmdNew": {
+        "suggested_key": {
+          "default": "Ctrl+Shift+1"
+        },
+        "global": true,
+        "description": "Create new window"
+    }
+  }
 }


### PR DESCRIPTION
The `commands` API is now stable according to https://codereview.chromium.org/253593003. Let's re-add back the commands key to the mini-code-edit manifest since it is already taking of it: https://github.com/GoogleChrome/chrome-app-samples/blob/master/mini-code-edit/background.js#L13-L13
