### PR TITLE
Fixed screenshots in sample READMEs

### DIFF
--- a/samples/analytics/README.md
+++ b/samples/analytics/README.md
@@ -19,5 +19,5 @@ Offline is also supported. See more at the [project wiki](https://github.com/Goo
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/analytics/assets/screenshot_1280_800.png)
+![screenshot](/samples/analytics/assets/screenshot_1280_800.png)
 

--- a/samples/appengine_channelapi/README.md
+++ b/samples/appengine_channelapi/README.md
@@ -21,5 +21,5 @@ To run:
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/appengine_channelapi/app/assets/screenshot_1280_800.png)
+![screenshot](/samples/appengine_channelapi/app/assets/screenshot_1280_800.png)
 

--- a/samples/appsquare/README.md
+++ b/samples/appsquare/README.md
@@ -24,5 +24,5 @@ The key *must* be removed before uploading it to the store.
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/appsquare/assets/screenshot_1280_800.png)
+![screenshot](/samples/appsquare/assets/screenshot_1280_800.png)
 

--- a/samples/blink1/README.md
+++ b/samples/blink1/README.md
@@ -19,4 +19,4 @@ On Linux a udev rule must be added to allow Chrome to open the blink(1) device. 
     SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="27b8", ATTRS{idProduct}=="01ed", MODE="0660", GROUP="plugdev"
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/blink1/assets/screenshot_1280_800.png)
+![screenshot](/samples/blink1/assets/screenshot_1280_800.png)

--- a/samples/bluetooth-samples/battery-service-demo/README.md
+++ b/samples/bluetooth-samples/battery-service-demo/README.md
@@ -10,4 +10,4 @@ with the Generic Attribute Profile (GATT) based Battery Service.
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/bluetooth-samples/battery-service-demo/assets/screenshot_1280_800.png)
+![screenshot](/samples/bluetooth-samples/battery-service-demo/assets/screenshot_1280_800.png)

--- a/samples/bluetooth-samples/device-info-demo/README.md
+++ b/samples/bluetooth-samples/device-info-demo/README.md
@@ -10,4 +10,4 @@ chrome.bluetoothLowEnergy API.
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/bluetooth-samples/device-info-demo/assets/screenshot_1280_800.png)
+![screenshot](/samples/bluetooth-samples/device-info-demo/assets/screenshot_1280_800.png)

--- a/samples/bluetooth-samples/heart-rate-sensor/README.md
+++ b/samples/bluetooth-samples/heart-rate-sensor/README.md
@@ -10,4 +10,4 @@ Bluetooth Low Energy heart rate sensor.
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/bluetooth-samples/heart-rate-sensor/assets/screenshot_1280_800.png)
+![screenshot](/samples/bluetooth-samples/heart-rate-sensor/assets/screenshot_1280_800.png)

--- a/samples/calculator/README.md
+++ b/samples/calculator/README.md
@@ -16,5 +16,5 @@ DOM manipulation.
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/calculator/assets/screenshot_1280_800.png)
+![screenshot](/samples/calculator/assets/screenshot_1280_800.png)
 

--- a/samples/camera-capture/README.md
+++ b/samples/camera-capture/README.md
@@ -15,5 +15,5 @@ to be set in the manifest file.
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/camera-capture/assets/screenshot_1280_800.png)
+![screenshot](/samples/camera-capture/assets/screenshot_1280_800.png)
 

--- a/samples/clock/README.md
+++ b/samples/clock/README.md
@@ -13,5 +13,5 @@ A widget-like application that provides a world clock, an alarm, a timer and a s
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/clock/assets/screenshot_1280_800.png)
+![screenshot](/samples/clock/assets/screenshot_1280_800.png)
 

--- a/samples/context-menu/README.md
+++ b/samples/context-menu/README.md
@@ -16,5 +16,5 @@ A single context menu structure is normally global to the entire app, and thus a
      
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/context-menu/assets/screenshot_1280_800.png)
+![screenshot](/samples/context-menu/assets/screenshot_1280_800.png)
 

--- a/samples/dart/README.md
+++ b/samples/dart/README.md
@@ -14,5 +14,5 @@ if you want to recompile dart to JS. See the correct, CSP compatible, command-li
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/dart/assets/screenshot_1280_800.png)
+![screenshot](/samples/dart/assets/screenshot_1280_800.png)
 

--- a/samples/desktop-capture/README.md
+++ b/samples/desktop-capture/README.md
@@ -14,4 +14,4 @@ the appropriate permissions (`desktopCapture`) to be set in the manifest file.
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/desktop-capture/assets/screenshot_1280_800.png)
+![screenshot](/samples/desktop-capture/assets/screenshot_1280_800.png)

--- a/samples/dialog-element/README.md
+++ b/samples/dialog-element/README.md
@@ -33,4 +33,4 @@ dialog.addEventListener("cancel", function(evt) {
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/dialog-element/assets/screenshot_1280_800.png)
+![screenshot](/samples/dialog-element/assets/screenshot_1280_800.png)

--- a/samples/diff/README.md
+++ b/samples/diff/README.md
@@ -16,5 +16,5 @@ A non-trivial application to diff two files choosen by the user. This app shows 
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/diff/assets/screenshot_1280_800.png)
+![screenshot](/samples/diff/assets/screenshot_1280_800.png)
 

--- a/samples/filesystem-access/README.md
+++ b/samples/filesystem-access/README.md
@@ -12,5 +12,5 @@ NOTE: This sample requires Milestone 31 or later of Chrome, since it uses the ne
 * [chrome.fileSystem](http://developer.chrome.com/apps/fileSystem.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/filesystem-access/assets/screenshot_1280_800.png)
+![screenshot](/samples/filesystem-access/assets/screenshot_1280_800.png)
 

--- a/samples/frameless-window/README.md
+++ b/samples/frameless-window/README.md
@@ -14,5 +14,5 @@ Caveat: `-webkit-app-region: drag;` *will* disable some customizations such as c
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/frameless-window/assets/screenshot_1280_800.png)
+![screenshot](/samples/frameless-window/assets/screenshot_1280_800.png)
 

--- a/samples/gcm-notifications/README.md
+++ b/samples/gcm-notifications/README.md
@@ -13,4 +13,4 @@ Demonstrates the capability to receive the push messages from Google Cloud Messa
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/gcm-notifications/assets/screenshot_1280_800.png)
+![screenshot](/samples/gcm-notifications/assets/screenshot_1280_800.png)

--- a/samples/gdrive/README.md
+++ b/samples/gdrive/README.md
@@ -14,4 +14,4 @@ To upload files: drag in files from the desktop onto the app.
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/gdrive/assets/screenshot_1280_800.png)
+![screenshot](/samples/gdrive/assets/screenshot_1280_800.png)

--- a/samples/github-auth/README.md
+++ b/samples/github-auth/README.md
@@ -21,5 +21,5 @@ Account check out the [Identity sample application](../identity).
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/github-auth/assets/screenshot_1280_800.png)
+![screenshot](/samples/github-auth/assets/screenshot_1280_800.png)
 

--- a/samples/hello-world-sync/README.md
+++ b/samples/hello-world-sync/README.md
@@ -28,5 +28,5 @@ Important: needs "key" in manifest.json to support testing outside of CWS, so th
 * [Storage sync](http://developer.chrome.com/extensions/storage.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/hello-world-sync/assets/screenshot_1280_800.png)
+![screenshot](/samples/hello-world-sync/assets/screenshot_1280_800.png)
 

--- a/samples/hello-world/README.md
+++ b/samples/hello-world/README.md
@@ -36,5 +36,5 @@ and, at that point, creates a window using a basic HTML page, index.html, as the
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/hello-world/assets/screenshot_1280_800.png)
+![screenshot](/samples/hello-world/assets/screenshot_1280_800.png)
 

--- a/samples/hid/README.md
+++ b/samples/hid/README.md
@@ -12,4 +12,4 @@ hardware of choice.
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/hid/assets/screenshot_1280_800.png)
+![screenshot](/samples/hid/assets/screenshot_1280_800.png)

--- a/samples/identity/README.md
+++ b/samples/identity/README.md
@@ -21,4 +21,4 @@ you should use the launchWebAuthFlow method instead.
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/identity/assets/screenshot_1280_800.png)
+![screenshot](/samples/identity/assets/screenshot_1280_800.png)

--- a/samples/image-edit/README.md
+++ b/samples/image-edit/README.md
@@ -12,4 +12,4 @@ Works offline.
 ## Try it: [Crop Tool - Image Edit](https://chrome.google.com/webstore/detail/crop-tool-image-edit/foibnkkcggahkmckladbmgkajodpcjfh)
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/image-edit/assets/screenshot_1280_800.png)
+![screenshot](/samples/image-edit/assets/screenshot_1280_800.png)

--- a/samples/in-app-payments-with-server-validation/README.md
+++ b/samples/in-app-payments-with-server-validation/README.md
@@ -4,5 +4,5 @@ This is a simple test/sample app showing how to use the in-app payments API in a
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/in-app-payments-with-server-validation/chromeapp/assets/screenshot_1280_800.png)
+![screenshot](/samples/in-app-payments-with-server-validation/chromeapp/assets/screenshot_1280_800.png)
 

--- a/samples/in-app-payments/README.md
+++ b/samples/in-app-payments/README.md
@@ -20,5 +20,5 @@ https://developers.google.com/commerce/wallet/digital/docs/testing
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/in-app-payments/assets/screenshot_1280_800.png)
+![screenshot](/samples/in-app-payments/assets/screenshot_1280_800.png)
 

--- a/samples/instagram-auth/README.md
+++ b/samples/instagram-auth/README.md
@@ -26,4 +26,4 @@ The key *must* be removed before uploading it to the store.
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/instagram-auth/assets/screenshot_1280_800.png)
+![screenshot](/samples/instagram-auth/assets/screenshot_1280_800.png)

--- a/samples/io2012-presentation/README.md
+++ b/samples/io2012-presentation/README.md
@@ -13,5 +13,5 @@ The `servo` directory contains the standalone version of the serial port API spi
 The `windowing_api` directory contains the source for the custom window frame and windowing API documentation (it's launched via the "Demo" link on slide 7).
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/io2012-presentation/assets/screenshot_1280_800.png)
+![screenshot](/samples/io2012-presentation/assets/screenshot_1280_800.png)
 

--- a/samples/ioio/README.md
+++ b/samples/ioio/README.md
@@ -16,5 +16,5 @@ The constants and information about the protocol was taken from https://github.c
 * [Bluetooth](http://developer.chrome.com/apps/bluetooth.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/ioio/assets/screenshot_1280_800.png)
+![screenshot](/samples/ioio/assets/screenshot_1280_800.png)
 

--- a/samples/keyboard-handler/README.md
+++ b/samples/keyboard-handler/README.md
@@ -11,7 +11,7 @@ be captured by a chrome packaged app, and learn what the appropriate keyCode
 is for them.
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/keyboard-handler/assets/screenshot_1280_800.png)
+![screenshot](/samples/keyboard-handler/assets/screenshot_1280_800.png)
 
 ## Credit
 

--- a/samples/manga-cam/README.md
+++ b/samples/manga-cam/README.md
@@ -14,4 +14,4 @@ Chrome Packaged App with `videoCapture` permission can query user media without 
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/manga-cam/assets/screenshot_1280_800.png)
+![screenshot](/samples/manga-cam/assets/screenshot_1280_800.png)

--- a/samples/mdns-browser/README.md
+++ b/samples/mdns-browser/README.md
@@ -15,5 +15,5 @@ This is a non-trivial sample which uses the UDP multicast support in Chrome Pack
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/mdns-browser/assets/screenshot_1280_800.png)
+![screenshot](/samples/mdns-browser/assets/screenshot_1280_800.png)
 

--- a/samples/media-gallery/README.md
+++ b/samples/media-gallery/README.md
@@ -13,5 +13,5 @@ This is a sample application that uses the [media gallery](http://developer.chro
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/media-gallery/assets/screenshot_1280_800.png)
+![screenshot](/samples/media-gallery/assets/screenshot_1280_800.png)
 

--- a/samples/messaging/README.md
+++ b/samples/messaging/README.md
@@ -9,5 +9,5 @@ This sample shows how to communicate between two apps or one app and one extensi
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/messaging/assets/screenshot_1280_800.png)
+![screenshot](/samples/messaging/assets/screenshot_1280_800.png)
 

--- a/samples/mini-code-edit/README.md
+++ b/samples/mini-code-edit/README.md
@@ -13,5 +13,5 @@ A non-trivial sample with basic features of a code editor, like syntax detection
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/mini-code-edit/assets/screenshot_1280_800.png)
+![screenshot](/samples/mini-code-edit/assets/screenshot_1280_800.png)
 

--- a/samples/multicast/README.md
+++ b/samples/multicast/README.md
@@ -18,5 +18,5 @@ __Warning: This is a simple chatting app demonstrating the usage of multicast so
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/multicast/assets/screenshot_1280_800.png)
+![screenshot](/samples/multicast/assets/screenshot_1280_800.png)
 

--- a/samples/one-time-payment/README.md
+++ b/samples/one-time-payment/README.md
@@ -20,4 +20,4 @@ to add the the key below to your manifest:
 * [Identity](http://developer.chrome.com/apps/identity.html)
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/one-time-payment/assets/screenshot_1280_800.png)
+![screenshot](/samples/one-time-payment/assets/screenshot_1280_800.png)

--- a/samples/optional-permissions/README.md
+++ b/samples/optional-permissions/README.md
@@ -13,5 +13,5 @@ This app shows to use the permissions API to request optional permissions. It ca
 * [Permissions](http://developer.chrome.com/apps/permissions.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/optional-permissions/assets/screenshot_1280_800.png)
+![screenshot](/samples/optional-permissions/assets/screenshot_1280_800.png)
 

--- a/samples/parrot-ar-drone/README.md
+++ b/samples/parrot-ar-drone/README.md
@@ -37,5 +37,5 @@ _Please note: this has only been tested with an Xbox 360 controller_
 _Thanks to felixge for the [Node AR Drone lib](https://github.com/felixge/node-ar-drone), which served as a helpful reference._
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/parrot-ar-drone/assets/screenshot_1280_800.png)
+![screenshot](/samples/parrot-ar-drone/assets/screenshot_1280_800.png)
 

--- a/samples/printing/README.md
+++ b/samples/printing/README.md
@@ -10,4 +10,4 @@ animation can be displayed on the control window to demonstrates how timers are
 suspended while printing.
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/printing/assets/screenshot_1280_800.png)
+![screenshot](/samples/printing/assets/screenshot_1280_800.png)

--- a/samples/push-guestbook/README.md
+++ b/samples/push-guestbook/README.md
@@ -46,5 +46,5 @@ How to install on your local machine:
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/push-guestbook/assets/screenshot_1280_800.png)
+![screenshot](/samples/push-guestbook/assets/screenshot_1280_800.png)
 

--- a/samples/push-messaging-roundtrip-sample/README.md
+++ b/samples/push-messaging-roundtrip-sample/README.md
@@ -45,5 +45,5 @@ to write your client code.
 * [GCM for Chrome server API](http://developer.chrome.com/apps/cloudMessaging.html)     
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/push-messaging-roundtrip-sample/assets/screenshot_1280_800.png)
+![screenshot](/samples/push-messaging-roundtrip-sample/assets/screenshot_1280_800.png)
 

--- a/samples/push-sample-app/README.md
+++ b/samples/push-sample-app/README.md
@@ -41,5 +41,5 @@ the sample app.
 * [Google Cloud Messaging for Chrome V1](https://developer.chrome.com/apps/cloudMessagingV1)
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/push-sample-app/assets/screenshot_1280_800.png)
+![screenshot](/samples/push-sample-app/assets/screenshot_1280_800.png)
 

--- a/samples/restarted-demo/README.md
+++ b/samples/restarted-demo/README.md
@@ -15,5 +15,5 @@ This demo app creates a new counter on launch and restores any existing counters
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/restarted-demo/assets/screenshot_1280_800.png)
+![screenshot](/samples/restarted-demo/assets/screenshot_1280_800.png)
 

--- a/samples/rich-notifications/README.md
+++ b/samples/rich-notifications/README.md
@@ -16,4 +16,4 @@ in the system tray. This API is still in experimental state.
 
 ## Screenshot
 
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/rich-notifications/assets/screenshot_1280_800.png)
+![screenshot](/samples/rich-notifications/assets/screenshot_1280_800.png)

--- a/samples/sandbox/README.md
+++ b/samples/sandbox/README.md
@@ -21,5 +21,5 @@ See more info on [using eval safely in packaged apps](http://developer.chrome.co
 * [Runtime](http://developer.chrome.com/apps/app.runtime.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/sandbox/assets/screenshot_1280_800.png)
+![screenshot](/samples/sandbox/assets/screenshot_1280_800.png)
 

--- a/samples/sandboxed-content/README.md
+++ b/samples/sandboxed-content/README.md
@@ -20,5 +20,5 @@ See more info on [using eval safely in packaged apps](http://developer.chrome.co
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/sandboxed-content/assets/screenshot_1280_800.png)
+![screenshot](/samples/sandboxed-content/assets/screenshot_1280_800.png)
 

--- a/samples/serial-control-signals/README.md
+++ b/samples/serial-control-signals/README.md
@@ -12,5 +12,5 @@ This sample demonstrates how you can send and receive control signals (DTR, RTS,
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/serial-control-signals/assets/screenshot_1280_800.png)
+![screenshot](/samples/serial-control-signals/assets/screenshot_1280_800.png)
 

--- a/samples/serial/adkjs/README.md
+++ b/samples/serial/adkjs/README.md
@@ -15,5 +15,5 @@ In the app directory, you will find the Chrome Packaged App.
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/serial/adkjs/app/assets/screenshot_1280_800.png)
+![screenshot](/samples/serial/adkjs/app/assets/screenshot_1280_800.png)
 

--- a/samples/serial/espruino/README.md
+++ b/samples/serial/espruino/README.md
@@ -19,4 +19,4 @@ This sample lets you toggle the state of an LED on an [Espruino JavaScript board
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/serial/espruino/assets/screenshot_1280_800.png)
+![screenshot](/samples/serial/espruino/assets/screenshot_1280_800.png)

--- a/samples/serial/ledtoggle/README.md
+++ b/samples/serial/ledtoggle/README.md
@@ -24,4 +24,4 @@ for Chrome packaged apps.
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/serial/ledtoggle/assets/screenshot_1280_800.png)
+![screenshot](/samples/serial/ledtoggle/assets/screenshot_1280_800.png)

--- a/samples/servo/README.md
+++ b/samples/servo/README.md
@@ -15,5 +15,5 @@ This app displays a slider that, when dragged, causes a servo attached to an Ard
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/servo/assets/screenshot_1280_800.png)
+![screenshot](/samples/servo/assets/screenshot_1280_800.png)
 

--- a/samples/storage/README.md
+++ b/samples/storage/README.md
@@ -13,5 +13,5 @@ A very basic application that demonstrates the Filesystem API. It allows you to 
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/storage/assets/screenshot_1280_800.png)
+![screenshot](/samples/storage/assets/screenshot_1280_800.png)
 

--- a/samples/syncfs-editor/README.md
+++ b/samples/syncfs-editor/README.md
@@ -25,5 +25,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/syncfs-editor/assets/screenshot_1280_800.png)
+![screenshot](/samples/syncfs-editor/assets/screenshot_1280_800.png)
 

--- a/samples/systemInfo/README.md
+++ b/samples/systemInfo/README.md
@@ -16,5 +16,5 @@ as CPU, memory and disk storage etc.
 
 ## Screenshot
 
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/systemInfo/assets/screenshot_1280_800.png)
+![screenshot](/samples/systemInfo/assets/screenshot_1280_800.png)
 

--- a/samples/tasks/README.md
+++ b/samples/tasks/README.md
@@ -15,4 +15,4 @@ of the [JavaScript Client Library](https://developers.google.com/api-client-libr
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/tasks/assets/screenshot_1280_800.png)
+![screenshot](/samples/tasks/assets/screenshot_1280_800.png)

--- a/samples/tcpserver/README.md
+++ b/samples/tcpserver/README.md
@@ -12,5 +12,5 @@ This is a sample that shows how you can run a network TCP server in a packaged a
 * [Window](https://developer.chrome.com/apps/app_window)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/tcpserver/assets/screenshot_1280_800.png)
+![screenshot](/samples/tcpserver/assets/screenshot_1280_800.png)
 

--- a/samples/telnet/README.md
+++ b/samples/telnet/README.md
@@ -22,5 +22,5 @@ Networking stuff, ANSI colors by Boris Smus.
 Terminal by Eric Bidelman: http://www.htmlfivewow.com/demos/terminal/terminal.html
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/telnet/assets/screenshot_1280_800.png)
+![screenshot](/samples/telnet/assets/screenshot_1280_800.png)
 

--- a/samples/text-editor/README.md
+++ b/samples/text-editor/README.md
@@ -13,5 +13,5 @@ A non-trivial sample with basic features of a code editor, like language detecti
 
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/text-editor/assets/screenshot_1280_800.png)
+![screenshot](/samples/text-editor/assets/screenshot_1280_800.png)
 

--- a/samples/udp/README.md
+++ b/samples/udp/README.md
@@ -34,5 +34,5 @@ In the `server` directory, you will find a Node echo server that intentionally d
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/udp/assets/screenshot_1280_800.png)
+![screenshot](/samples/udp/assets/screenshot_1280_800.png)
 

--- a/samples/url-handler/README.md
+++ b/samples/url-handler/README.md
@@ -19,4 +19,4 @@ Note that at least in this initial version of the feature in Chrome 31 stable ch
 * [chrome.storage](http://developer.chrome.com/apps/storage.html)
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/url-handler/assets/screenshot_1280_800.png)
+![screenshot](/samples/url-handler/assets/screenshot_1280_800.png)

--- a/samples/usb-label-printer/README.md
+++ b/samples/usb-label-printer/README.md
@@ -49,5 +49,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/usb-label-printer/assets/screenshot_1280_800.png)
+![screenshot](/samples/usb-label-printer/assets/screenshot_1280_800.png)
 

--- a/samples/usb/knob/README.md
+++ b/samples/usb/knob/README.md
@@ -12,5 +12,5 @@ This demo interfaces with a [Griffin PowerMate](http://en.wikipedia.org/wiki/Gri
 * [Window](https://developer.chrome.com/apps/app_window)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/usb/knob/assets/screenshot_1280_800.png)
+![screenshot](/samples/usb/knob/assets/screenshot_1280_800.png)
 

--- a/samples/weather/README.md
+++ b/samples/weather/README.md
@@ -18,5 +18,5 @@ that the user has chosen
 * [Geolocation](http://developer.chrome.com/apps/manifest.html#permissions)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/weather/assets/screenshot_1280_800.png)
+![screenshot](/samples/weather/assets/screenshot_1280_800.png)
 

--- a/samples/web-store/README.md
+++ b/samples/web-store/README.md
@@ -13,4 +13,4 @@ Lets you upload and publish Chrome Apps and Extensions folders stored locally on
 * [storage](http://developer.chrome.com/apps/storage)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/web-store/assets/screenshot_1280_800.png)
+![screenshot](/samples/web-store/assets/screenshot_1280_800.png)

--- a/samples/webserver/README.md
+++ b/samples/webserver/README.md
@@ -82,5 +82,5 @@ The `listen` and `accept` API are currently only available in Canary channel of 
 "Experimental extensions" mode (set via chrome://flags).
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/webserver/assets/screenshot_1280_800.png)
+![screenshot](/samples/webserver/assets/screenshot_1280_800.png)
 

--- a/samples/websocket-server/README.md
+++ b/samples/websocket-server/README.md
@@ -13,4 +13,4 @@ An example Http and WebSocket server implementation with a sample app which serv
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/websocket-server/assets/screenshot_1280_800.png)
+![screenshot](/samples/websocket-server/assets/screenshot_1280_800.png)

--- a/samples/webview-samples/browser/README.md
+++ b/samples/webview-samples/browser/README.md
@@ -21,4 +21,4 @@ reliability of your application.
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/webview-samples/browser/assets/screenshot_1280_800.png)
+![screenshot](/samples/webview-samples/browser/assets/screenshot_1280_800.png)

--- a/samples/webview-samples/new-window-user-agent/README.md
+++ b/samples/webview-samples/new-window-user-agent/README.md
@@ -37,4 +37,4 @@ Sample](https://github.com/GoogleChrome/chrome-app-samples/tree/master/webview-s
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/webview-samples/new-window-user-agent/assets/screenshot_1280_800.png)
+![screenshot](/samples/webview-samples/new-window-user-agent/assets/screenshot_1280_800.png)

--- a/samples/webview-samples/shared-script/README.md
+++ b/samples/webview-samples/shared-script/README.md
@@ -35,4 +35,4 @@ the script directly and *Correct injection* injects the script into a
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/webview-samples/shared-script/assets/screenshot_1280_800.png)
+![screenshot](/samples/webview-samples/shared-script/assets/screenshot_1280_800.png)

--- a/samples/webview-samples/webview/README.md
+++ b/samples/webview-samples/webview/README.md
@@ -13,4 +13,4 @@ Sample to explore some of the APIs in the webview tag.
 
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/webview-samples/webview/assets/screenshot_1280_800.png)
+![screenshot](/samples/webview-samples/webview/assets/screenshot_1280_800.png)

--- a/samples/window-options/README.md
+++ b/samples/window-options/README.md
@@ -17,5 +17,5 @@ This sample requires Chrome Version 35 or higher.
 * [Window](http://developer.chrome.com/apps/app.window.html)
 
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/window-options/assets/screenshot_1280_800.png)
+![screenshot](/samples/window-options/assets/screenshot_1280_800.png)
 

--- a/samples/window-state/README.md
+++ b/samples/window-state/README.md
@@ -12,5 +12,5 @@ and hidden states. Includes HTML5 requestFullscreen and app.window.fullscreen().
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/window-state/assets/screenshot_1280_800.png)
+![screenshot](/samples/window-state/assets/screenshot_1280_800.png)
 

--- a/samples/windows/README.md
+++ b/samples/windows/README.md
@@ -12,5 +12,5 @@ The app creates two windows, an "original" window and a "copycat" window. The co
 * [Window](http://developer.chrome.com/apps/app.window.html)
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/windows/assets/screenshot_1280_800.png)
+![screenshot](/samples/windows/assets/screenshot_1280_800.png)
 

--- a/samples/zephyr_hxm/README.md
+++ b/samples/zephyr_hxm/README.md
@@ -20,5 +20,5 @@ Very simple Zephyr HXM heart rate monitor driver. This sample uses the bluetooth
 * http://www.highcharts.com/ to display the data inside of a sandboxed iframe
      
 ## Screenshot
-![screenshot](https://raw.github.com/GoogleChrome/chrome-app-samples/master/zephyr_hxm/assets/screenshot_1280_800.png)
+![screenshot](/samples/zephyr_hxm/assets/screenshot_1280_800.png)
 


### PR DESCRIPTION
I successfully ran to update screenshots in samples READMEs:

```
find . -name "README.md" -print | xargs sed -i 's/\[screenshot\](https:\/\/raw.github.com\/GoogleChrome\/chrome-app-samples\/master\//\[screenshot\](\/samples\//g'
```

BUG=#310
TBR=@mangini
