### PR TITLE
usb_device-info: Handle the case of a device being selected again.

### DIFF
--- a/samples/usb/device-info/manifest.json
+++ b/samples/usb/device-info/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "USB Device Info",
-  "version": "0.1",
+  "version": "0.2",
   "description": "This application displays detailed technical information about USB devices that are connected to your computer.",
   "manifest_version": 2,
   "minimum_chrome_version": "40.0.2202.3",

--- a/samples/usb/device-info/script.js
+++ b/samples/usb/device-info/script.js
@@ -30,7 +30,7 @@ function deviceSelectionChanged() {
     el.textContent = 'No device selected.';
     device_info.appendChild(el);
   } else {
-    var device = devices[device_selector.options.item(index).value];
+    var device = devices[device_selector.options.item(index).value].device;
 
     appendDeviceInfo(
         'Product ID',
@@ -97,7 +97,11 @@ chrome.usb.getDevices({}, function(found_devices) {
   }
 
   for (var device of found_devices) {
-    devices[device.device] = device;
+    var deviceInfo = {
+      'device': device,
+      'index': device_selector.options.length
+    };
+    devices[device.device] = deviceInfo;
     appendToDeviceSelector(device);
   }
 });
@@ -113,13 +117,15 @@ add_device.addEventListener('click', function() {
     }
 
     for (var device of selected_devices) {
-      if (device.deviceId in devices) {
-        continue;
+      var deviceInfo = { 'device': device, 'index': undefined };
+      if (device.device in devices) {
+        deviceInfo = devices[device.device];
+      } else {
+        deviceInfo.index = device_selector.options.length;
+        devices[device.device] = deviceInfo;
+        appendToDeviceSelector(device);
       }
-
-      devices[device.device] = device;
-      appendToDeviceSelector(device);
-      device_selector.selectedIndex = device_selector.options.length - 1;
+      device_selector.selectedIndex = deviceInfo.index;
       deviceSelectionChanged();
     }
   });


### PR DESCRIPTION
If the user selects a device that the app has already been given permission
for then this patch moves the selection back to that device instead of adding
a duplicate entry to its internal list.
