### PR TITLE
 bluetooth-samples_heart-rate-sensor: Don't disconnect same device of GATT services

### DIFF
--- a/samples/bluetooth-samples/heart-rate-sensor/main.js
+++ b/samples/bluetooth-samples/heart-rate-sensor/main.js
@@ -27,7 +27,7 @@ var main = (function() {
     // |serviceId| is undefined.
     UI.getInstance().resetState(!service);
 
-    if (this.service_) {
+    if (this.service_ && (!service || this.service_.deviceAddress !== service.deviceAddress)) {
       chrome.bluetoothLowEnergy.disconnect(this.service_.deviceAddress);
     }
 


### PR DESCRIPTION
I have tested this sample app on ChromeOS, and I found that services of same device will disconnect the BLE connection. For example:

When some characteristic discovered on a service, onServiceChanged events listener will call this function, `this.service_` and `service` will have same `deviceAddress`. The device will be disconnected.
