### PR TITLE
Updated samples\hid to use correct hid.receive()

### DIFF
--- a/samples/hid/manifest.json
+++ b/samples/hid/manifest.json
@@ -13,8 +13,7 @@
 		{
 			"usbDevices": [
 				{ "vendorId": 0, "productId": 65535 },
-				{ "vendorId": 65535, "productId": 0 },
-				{ "vendorId": 5538, "productId": 512}
+				{ "vendorId": 65535, "productId": 0 }
  			]
 		}
 	]


### PR DESCRIPTION
chrome.hid.receive() was incorrect per
https://developer.chrome.com/apps/hid#method-receive. Needs to be
changed to be functional.
