### PR TITLE
Cookie sharing example

### DIFF
--- a/examples/cookie-sharing/background.js
+++ b/examples/cookie-sharing/background.js
@@ -1,0 +1,10 @@
+chrome.action.onClicked.addListener(async (tab) => {
+  const url = "https://crx-cookie-sharing.glitch.me/dreams";
+  const res = await fetch(url, {credentials: "include"});
+
+  let cookies = await chrome.cookies.getAll({
+    domain: chrome.runtime.getURL(''),
+  });
+
+  console.log(cookies);
+});

--- a/examples/cookie-sharing/manifest.json
+++ b/examples/cookie-sharing/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "Sharing Cookies via CORS",
+  "description": "This extension demonstrates how a extension and coordinating website can share cookies.",
+  "version": "1.0",
+  "manifest_version": 3,
+  "background": {
+    "service_worker": "wrapper.js"
+  },
+  "action": { },
+  "permissions": [
+    "cookies"
+  ],
+  "host_permissions": [
+    "*://crx-sharing-cookies.glitch.me/*"
+  ],
+  "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCyQl/dWkS0lfmSPPuAdpnnjjU4LQ5Wp6Fn1ecriiRApmixldgk9GDmgJBT2CoDHfriSSM7eeMqiiR+tQbQ5rePVUeLGHtj7RiW6WjGdYKrb9Kn1XJzqK0Xxu8Uvh4GSw1q1BKCuCfs/2qpVrDOFyP4INrnGxVm4Fd/mvSVmEmB+SNxioZfMEW+8kbaQe1enALpOzrlFUnPJSG0G17mLzWoqKczklNQUdpAKkNK+Lmxb4yAy5+WLztK96NiDIJmNZ+L7xQWa4Imbdjt4gM/ZsRExHbvMHoo9etVjupvH3FdGffJlRostti6sGG6mZvLJiXsKBXz4UR+uBCb/ragczAB"
+}

--- a/examples/cookie-sharing/wrapper.js
+++ b/examples/cookie-sharing/wrapper.js
@@ -1,0 +1,5 @@
+try {
+  importScripts("background.js");
+} catch (e) {
+  console.log(e);
+}


### PR DESCRIPTION
This PR introduces a new Extensions example demonstrating how a coordinating website can share cookies with an extension. 