### PR TITLE
Alarms API demo

### DIFF
--- a/api/alarms/background.js
+++ b/api/alarms/background.js
@@ -1,0 +1,5 @@
+chrome.runtime.onInstalled.addListener((_reason) => {
+  chrome.tabs.create({
+    url: chrome.runtime.getURL('index.html')
+  });
+});

--- a/api/alarms/background.js
+++ b/api/alarms/background.js
@@ -1,5 +1,11 @@
+// Open the extension's demo page on install/update
 chrome.runtime.onInstalled.addListener((_reason) => {
   chrome.tabs.create({
     url: chrome.runtime.getURL('index.html')
   });
+});
+
+chrome.alarms.create('demo-default-alarm', {
+  delayInMinutes: 1,
+  periodInMinutes: 1,
 });

--- a/api/alarms/bg-wrapper.js
+++ b/api/alarms/bg-wrapper.js
@@ -1,0 +1,5 @@
+try {
+  importScripts('background.js');
+} catch (error) {
+  console.error(error);
+}

--- a/api/alarms/index.css
+++ b/api/alarms/index.css
@@ -1,0 +1,53 @@
+:root {
+  --card-min-width: 20em;
+  --card-max-width: 25em;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-size: 16px;
+}
+
+#display {
+  background-color: rgba(0, 0, 0, 15%);
+  min-height: 5em;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 15%);
+
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--card-min-width), 1fr));
+  column-gap: 10px;
+  row-gap: 15px;
+  padding: 10px 15px;
+}
+
+.alarm-info {
+  background-color: rgb(255, 255, 255);
+  min-height: 5em;
+  border-radius: 3px;
+  border: 1px solid rgb(193 193 193);
+  padding: 1em 2em;
+  min-width: var(--card-min-width);
+  max-width: var(--card-max-width);
+}
+
+.alarm-info__table {
+  border-collapse: collapse;
+}
+
+.alarm-info--fired {
+  background: repeating-linear-gradient(135deg, #eee, #eee 10px, #ddd 10px, #ddd 20px);
+}
+
+.alarm-info td,
+.alarm-info th {
+  padding: 0.2em 0.5em;
+}
+
+.alarm-info-label {
+  text-align: right;
+}
+

--- a/api/alarms/index.css
+++ b/api/alarms/index.css
@@ -30,15 +30,13 @@ body {
   border-radius: 3px;
   border: 1px solid rgb(193 193 193);
   padding: 1em 2em;
-  min-width: var(--card-min-width);
-  max-width: var(--card-max-width);
 }
 
 .alarm-info__table {
   border-collapse: collapse;
 }
 
-.alarm-info--fired {
+.alarm-info--finished {
   background: repeating-linear-gradient(135deg, #eee, #eee 10px, #ddd 10px, #ddd 20px);
 }
 
@@ -51,3 +49,23 @@ body {
   text-align: right;
 }
 
+/* **** */
+
+.create-alarm {
+  display: grid;
+  grid-template-columns: minmax(100px, 1fr) minmax(150px, 2fr);
+  column-gap: 20px;
+  row-gap: 10px;
+
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.create-alarm__label {
+  text-align: right;
+  font-weight: bold;
+}
+
+.create-alarm__submit {
+  grid-column: 1 / -1;
+}

--- a/api/alarms/index.html
+++ b/api/alarms/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <link rel="stylesheet" href="index.css">
+  <script defer src="index.js"></script>
+</head>
+<body>
+  <!--
+    |-[ refresh ]----------------------------------[ clear all ]-|
+    |                                                            |
+    | Alarm: Foo [delete]                                        |
+    | Will fire in X seconds                                     |
+    |                                                            |
+    |------------------------------------------------------------|
+
+    Create a new alarm
+
+    When:
+      (*) in X minutes
+      ( ) in Y MS
+
+      [       ]
+
+    Period:
+      [X] enable
+
+      every [       ] minutes
+
+   -->
+   <section>
+    <h2>Current Alarms</h2>
+
+    <button id="clear-display">Cancel all alarms</button>
+    <button id="refresh-display">Refresh</button>
+
+    <div id="display">
+      <div class="alarm-info">
+        <dl>
+          <dt>Name</dt>
+          <dd><span class="alarm__name">Foo</span></dd>
+
+          <dt>Schedule</dt>
+          <dd><span class="alarm__schedule">2021-03-24T15:29:05.355Z</span></dd>
+          <dd>Every <span class="alarm__period">2 minutes</span></dd>
+        </dl>
+      </div>
+
+      <div class="alarm-info alarm-info--fired">
+        <table class="alarm-info__table">
+          <tr>
+            <th class="alarm-info-label">Alarm Name</th>
+            <td class="alarm__name">Bar</td>
+          </tr>
+          <tr>
+            <th class="alarm-info-label">Status</th>
+            <td class="alarm__status">Completed</td>
+          </tr>
+          <tr>
+            <th class="alarm-info-label">Next Tick</th>
+            <td class="alarm__schedule">2021-03-24T15:31:27.051Z</td>
+          </tr>
+          <tr>
+            <th class="alarm-info-label">Period</th>
+            <td>One-time</td>
+          </tr>
+        </table>
+      </div>
+
+      <div class="alarm-info">
+        <table class="alarm-info__table">
+          <tr>
+            <th class="alarm-info-label">Name</th>
+            <td class="alarm__name">Baz</td>
+          </tr>
+          <tr>
+            <th class="alarm-info-label">Status</th>
+            <td class="alarm__status">Scheduled</td>
+          </tr>
+          <tr>
+            <th class="alarm-info-label">Next Tick</th>
+            <td class="alarm__schedule">2021-03-24T15:29:05.355Z</td>
+          </tr>
+          <tr>
+            <th class="alarm-info-label">Period</th>
+            <td>Every <span class="alarm__period">1</span> minute(s)</td>
+          </tr>
+        </table>
+      </div>
+
+    </div>
+  </section>
+
+  <section>
+    <h2>Create a new alarm</h2>
+
+    <form id="create-alarm">
+
+      <label>Alarm name <input type="text" name="alarm-name"></label>
+
+      <fieldset>
+        <legend>Time format</legend>
+
+        <input type="radio" name="time-format" id="format-minutes" value="min" checked>
+        <label for="format-minutes">Minutes</label>
+
+        <input type="radio" name="time-format" id="format-ms" value="ms">
+        <label for="format-ms">Milliseconds</label>
+      </fieldset>
+
+      <label>Time value
+        <input type="number" name="time-value" value=1>
+      </label>
+
+      <fieldset>
+        <legend>Periodic</legend>
+
+        <div class="row">
+          <label>
+            <input type="checkbox" name="is-periodic">
+            Enable periodic alarm
+          </label>
+        </div>
+
+        <div class="row">
+          <label>
+            Specify period in Minutes
+            <input type="number" name="period">
+          </label>
+        </div>
+      </fieldset>
+
+      <br>
+      <button type="submit">Submit</button>
+    </form>
+<!--
+    When:
+      (*) in X minutes
+      ( ) in Y MS
+
+      [       ]
+
+    Period:
+      [X] enable
+
+      every [       ] minutes -->
+
+    <div>
+
+    </div>
+  </section>
+
+
+  <!-- Clear
+  ClearAll
+  Create
+  Get
+  getAll -->
+
+
+</body>
+</html>

--- a/api/alarms/index.html
+++ b/api/alarms/index.html
@@ -6,160 +6,47 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Document</title>
   <link rel="stylesheet" href="index.css">
+  <script defer src="lib/alarmManager.js"></script>
   <script defer src="index.js"></script>
 </head>
 <body>
-  <!--
-    |-[ refresh ]----------------------------------[ clear all ]-|
-    |                                                            |
-    | Alarm: Foo [delete]                                        |
-    | Will fire in X seconds                                     |
-    |                                                            |
-    |------------------------------------------------------------|
-
-    Create a new alarm
-
-    When:
-      (*) in X minutes
-      ( ) in Y MS
-
-      [       ]
-
-    Period:
-      [X] enable
-
-      every [       ] minutes
-
-   -->
    <section>
     <h2>Current Alarms</h2>
 
-    <button id="clear-display">Cancel all alarms</button>
-    <button id="refresh-display">Refresh</button>
-
-    <div id="display">
-      <div class="alarm-info">
-        <dl>
-          <dt>Name</dt>
-          <dd><span class="alarm__name">Foo</span></dd>
-
-          <dt>Schedule</dt>
-          <dd><span class="alarm__schedule">2021-03-24T15:29:05.355Z</span></dd>
-          <dd>Every <span class="alarm__period">2 minutes</span></dd>
-        </dl>
-      </div>
-
-      <div class="alarm-info alarm-info--fired">
-        <table class="alarm-info__table">
-          <tr>
-            <th class="alarm-info-label">Alarm Name</th>
-            <td class="alarm__name">Bar</td>
-          </tr>
-          <tr>
-            <th class="alarm-info-label">Status</th>
-            <td class="alarm__status">Completed</td>
-          </tr>
-          <tr>
-            <th class="alarm-info-label">Next Tick</th>
-            <td class="alarm__schedule">2021-03-24T15:31:27.051Z</td>
-          </tr>
-          <tr>
-            <th class="alarm-info-label">Period</th>
-            <td>One-time</td>
-          </tr>
-        </table>
-      </div>
-
-      <div class="alarm-info">
-        <table class="alarm-info__table">
-          <tr>
-            <th class="alarm-info-label">Name</th>
-            <td class="alarm__name">Baz</td>
-          </tr>
-          <tr>
-            <th class="alarm-info-label">Status</th>
-            <td class="alarm__status">Scheduled</td>
-          </tr>
-          <tr>
-            <th class="alarm-info-label">Next Tick</th>
-            <td class="alarm__schedule">2021-03-24T15:29:05.355Z</td>
-          </tr>
-          <tr>
-            <th class="alarm-info-label">Period</th>
-            <td>Every <span class="alarm__period">1</span> minute(s)</td>
-          </tr>
-        </table>
-      </div>
-
+    <div id="display-buttons">
+      <button id="clear-display">Cancel all alarms</button>
+      <button id="refresh-display" title="Clear display and re-recreate alarm UI">Refresh</button>
     </div>
+
+    <div id="display"></div>
   </section>
 
   <section>
-    <h2>Create a new alarm</h2>
+    <h2>Create Alarm</h2>
+    <form class="create-alarm">
+      <div class="create-alarm__label">Name</div>
+      <div class="create-alarm__value">
+        <input type="text" name="alarm-name" value="my-alarm">
+      </div>
 
-    <form id="create-alarm">
+      <div class="create-alarm__label">Initial delay</div>
+      <div class="create-alarm__value">
+        <input type="number" step="0.01" name="time-value" min="0" value=1>
 
-      <label>Alarm name <input type="text" name="alarm-name"></label>
+        <select name="time-format">
+          <option id="format-minutes" value="min" selected>minutes</option>
+          <option id="format-ms" value="ms">milliseconds</option>
+        </select>
+      </div>
 
-      <fieldset>
-        <legend>Time format</legend>
+      <div class="create-alarm__label">Alarm period</div>
+      <div class="create-alarm__value">
+        <input type="number" step="0.01" min="0" name="period" value="0"> minutes
+        <br><i>Set to a non-zero value to create a periodic alarm.</i>
+      </div>
 
-        <input type="radio" name="time-format" id="format-minutes" value="min" checked>
-        <label for="format-minutes">Minutes</label>
-
-        <input type="radio" name="time-format" id="format-ms" value="ms">
-        <label for="format-ms">Milliseconds</label>
-      </fieldset>
-
-      <label>Time value
-        <input type="number" name="time-value" value=1>
-      </label>
-
-      <fieldset>
-        <legend>Periodic</legend>
-
-        <div class="row">
-          <label>
-            <input type="checkbox" name="is-periodic">
-            Enable periodic alarm
-          </label>
-        </div>
-
-        <div class="row">
-          <label>
-            Specify period in Minutes
-            <input type="number" name="period">
-          </label>
-        </div>
-      </fieldset>
-
-      <br>
-      <button type="submit">Submit</button>
+      <button type="submit" class="create-alarm__submit">Submit</button>
     </form>
-<!--
-    When:
-      (*) in X minutes
-      ( ) in Y MS
-
-      [       ]
-
-    Period:
-      [X] enable
-
-      every [       ] minutes -->
-
-    <div>
-
-    </div>
   </section>
-
-
-  <!-- Clear
-  ClearAll
-  Create
-  Get
-  getAll -->
-
-
 </body>
 </html>

--- a/api/alarms/index.js
+++ b/api/alarms/index.js
@@ -1,102 +1,100 @@
 let display = document.getElementById('display');
-let form = document.getElementById('create-alarm');
+let form = document.querySelector('.create-alarm');
 let clearButton = document.getElementById('clear-display');
 let refreshButton = document.getElementById('refresh-display');
 
-let alarmManager = new AlarmManager();
-
-// Chrome event bindings
-
-chrome.alarms.onAlarm.addListener(alarm => {
-  console.log('alarm fired', alarm);
-});
+let alarmManager = new AlarmManager({ display });
 
 // DOM event bindings
 
 //// Alarm display buttons
 
 clearButton.addEventListener('click', cancelAllAlarms);
+refreshButton.addEventListener('click', refreshAlarmDisplay);
 
 //// New alarm form
 
 form.addEventListener('submit', (event) => {
   event.preventDefault();
-  new FormData(form);
+  let formData = new FormData(form);
+  let data = Object.fromEntries(formData);
+
+  let name = data['alarm-name'];
+  let delay = Number.parseFloat(data['time-value']);
+  let delayFormat = data['time-format'];
+  let period = Number.parseFloat(data['period']);
+
+  createAlarm({ name, delay, delayFormat, period });
 });
 
-form.addEventListener('formdata', (event) =>{
-  let {formData} = event;
+// Initialize display
 
-  for (let [formKey, formValue] of formData) {
-    console.log(formKey, formValue);
-  }
-  console.log('---');
-});
+refreshAlarmDisplay();
 
-// Individual alarm UI
-class AlarmManager {
-  constructor(displayElement) {
-    this.display = displayElement;
-    this.alarmListener = alarm => this.handleAlarmFired(alarm);
+// ???
 
-    chrome.alarms.onAlarm.addListener(this.alarmListener);
-  }
-
-  destroy() {
-    chrome.alarms.onAlarm.removeListener(this.alarmListener);
-  }
-
-  /**
-   * @param {Object} options
-   * @param {string} options.name
-   * @param {number} options.delay
-   * @param {"ms"|"min"} options.delayFormat;
-   * @param {number} options.period;
-   */
-  create(options) {
-    let alarmInfo = {};
-
-    if (options.delayFormat == 'ms') {
-      // specified in milliseconds, use `when` property
-      alarmInfo.when = options.delay;
-    } else {
-      // assume minutes, use `delayInMinutes` property
-      alarmInfo.delayInMinutes = options.delay;
-    }
-
-    if (options.period) {
-      alarmInfo.periodInMinutes = options.period;
-    }
-
-    chrome.alarms.create(options.name, alarmInfo);
-  }
-
-  async clear(name) {
-    return new Promise((resolve, reject) => {
-      chrome.alarms.clear(name, (wasCleared) => {
-        let data = { name, wasCleared };
-        if (wasCleared) {
-          resolve(data);
-        } else {
-          reject(data);
-        }
-      });
-    });
-  }
-
-  clearAll() {
-    chrome.alarm.clearAll((wasCleared) => {
-      // update alarm display to show all have been canceled
-    });
-  }
-
-  handleAlarmFired() {
-
-  }
+function destroyAllAlarms() {
+  [...display.children].forEach(alarm => {
+    alarm.destroy();
+  })
 }
 
-class ExtensionAlarm extends HTMLElement{
-  static extensionAlarmTemplate = document.createElement('template');
+function cancelAllAlarms() {
+  chrome.alarms.clearAll();
+  destroyAllAlarms();
+}
+
+function refreshAlarmDisplay() {
+  destroyAllAlarms();
+  chrome.alarms.getAll((alarms) => {
+    for (let alarm of alarms) {
+      let el = document.createElement('crx-alarm');
+      el.setAttribute('alarm-name', alarm.name);
+      display.appendChild(el);
+    }
+  });
+}
+
+/**
+ * @param {Object} options
+ * @param {string} options.name
+ * @param {number} options.delay
+ * @param {"ms"|"min"} options.delayFormat;
+ * @param {number} options.period;
+ */
+function createAlarm(options) {
+  let alarmInfo = {};
+
+  if (options.delayFormat === 'ms') {
+    // Specified in milliseconds, use `when` property
+    //
+    // This takes a fixed timestamp in ms since Unix epoch.
+    alarmInfo.when = Date.now() + options.delay;
+  } else if (options.delayFormat === 'min') {
+    // specified in minutes, use `delayInMinutes` property
+    alarmInfo.delayInMinutes = options.delay;
+  } else {
+    throw new Error(`Unknown time format provided ("${options.delayFormat}"). Known values are "ms" and "min".`);
+  }
+
+  if (options.period) {
+    alarmInfo.periodInMinutes = options.period;
+  }
+
+  chrome.alarms.create(options.name, alarmInfo);
+
+  let el = display.querySelectorAll(`[alarm-name="${options.name}"]`);
+
+  // Instantiate crx-alarm instance for this alarm
+  let alarm = document.createElement('crx-alarm');
+  alarm.setAttribute('alarm-name', options.name);
+  display.appendChild(alarm);
+}
+
+// Alarm Element
+
+class ExtensionAlarm extends HTMLElement {
+  static template = document.createElement('template');
 
   constructor() {
     super();
@@ -104,30 +102,86 @@ class ExtensionAlarm extends HTMLElement{
     // Instantiate template
     let template = ExtensionAlarm.template.content.cloneNode(true);
 
-    this.shadowRoot = this.attachShadow({mode: 'open'});
-    this.shadowRoot.appendChild(template);
+    this._shadowRoot = this.attachShadow({ mode: 'open' });
+    this._shadowRoot.appendChild(template);
 
     // Store references to dynamically driven UI values
-    this.rootEl = template.querySelector('.alarm-info');
-    this.nameEl = template.querySelector('.alarm__name');
-    this.statusEl = template.querySelector('.alarm__status');
-    this.scheduleEl = template.querySelector('.alarm__schedule');
-    this.periodEl = template.querySelector('.alarm__period');
+    this.rootEl = this._shadowRoot.querySelector('.alarm-info');
+    this.nameEl = this._shadowRoot.querySelector('.alarm__name');
+    this.statusEl = this._shadowRoot.querySelector('.alarm__status');
+    this.scheduleEl = this._shadowRoot.querySelector('.alarm__schedule');
+    this.periodEl = this._shadowRoot.querySelector('.alarm__period');
+
+    this.boundAlarmHandler = this.handleAlarmFired.bind(this);
   }
 
-  handleAlarmFired() {
-    let isPeriodic = false;
-    if (isPeriodic) return;
+  static get observedAttributes() {
+    return ['alarm-name'];
+  }
 
-    this.rootEl.classList.add('alarm-info--fired');
+  attributeChangedCallback(attName, _oldAttrValue, newAttrValue) {
+    if (attName === 'alarm-name') {
+      chrome.alarms.get(newAttrValue, alarm => this.render(alarm));
+      this.unbind();
+      chrome.alarms.onAlarm.addListener(this.boundAlarmHandler);
+    }
+  }
+
+  render(alarm) {
+    if (!alarm) {
+      throw new Error('Attempting to render an alarm, but no alarm data provided');
+    }
+
+    // Render current alarm data
+    this.nameEl.innerText = alarm.name;
+
+    let date = new Date(alarm.scheduledTime);
+    this.scheduleEl.innerText = date.toISOString();
+
+    if (alarm.scheduledTime > Date.now()) {
+      this.statusEl.innerText = 'Scheduled';
+    }
+
+    if (alarm.periodInMinutes) {
+      this.periodEl.innerText = `Every ${alarm.periodInMinutes} minute(s)`
+    } else {
+      this.periodEl.innerText = 'One-time';
+    }
+  }
+
+  handleAlarmFired(alarm) {
+    // We're registered for updates on all alarms, but we only care about our own
+    if (alarm.name !== this.getAttribute('alarm-name')) {
+      return;
+    }
+
+    if (alarm.periodInMinutes) {
+      this.render(alarm);
+    } else {
+      this.rootEl.classList.add('alarm-info--finished');
+      this.statusEl.innerText = 'Completed';
+      this.unbind();
+    }
+  }
+
+  unbind() {
+    if (this.boundAlarmHandler) {
+      chrome.alarms.onAlarm.removeListener(this.boundAlarmHandler);
+    }
+  }
+
+  destroy() {
+    this.unbind();
+    this.parentElement.removeChild(this);
   }
 }
 
 ExtensionAlarm.template.innerHTML = `
+<link rel="stylesheet" href="index.css">
 <div class="alarm-info">
   <table class="alarm-info__table">
     <tr>
-      <th class="alarm-info-label">Alarm Name</th>
+      <th class="alarm-info-label">Name</th>
       <td class="alarm__name"></td>
     </tr>
     <tr>
@@ -135,7 +189,7 @@ ExtensionAlarm.template.innerHTML = `
       <td class="alarm__status"></td>
     </tr>
     <tr>
-      <th class="alarm-info-label">Next Tick</th>
+      <th class="alarm-info-label">Next&nbsp;Tick</th>
       <td class="alarm__schedule"></td>
     </tr>
     <tr>
@@ -146,9 +200,4 @@ ExtensionAlarm.template.innerHTML = `
 </div>
 `;
 
-let knownAlarms = new Set();
-
-function cancelAllAlarms() {
-  chrome.alarms.clearAll();
-  display.innerHTML = '';
-}
+customElements.define('crx-alarm', ExtensionAlarm);

--- a/api/alarms/index.js
+++ b/api/alarms/index.js
@@ -1,0 +1,154 @@
+let display = document.getElementById('display');
+let form = document.getElementById('create-alarm');
+let clearButton = document.getElementById('clear-display');
+let refreshButton = document.getElementById('refresh-display');
+
+let alarmManager = new AlarmManager();
+
+// Chrome event bindings
+
+chrome.alarms.onAlarm.addListener(alarm => {
+  console.log('alarm fired', alarm);
+});
+
+// DOM event bindings
+
+//// Alarm display buttons
+
+clearButton.addEventListener('click', cancelAllAlarms);
+
+//// New alarm form
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  new FormData(form);
+});
+
+form.addEventListener('formdata', (event) =>{
+  let {formData} = event;
+
+  for (let [formKey, formValue] of formData) {
+    console.log(formKey, formValue);
+  }
+  console.log('---');
+});
+
+// Individual alarm UI
+class AlarmManager {
+  constructor(displayElement) {
+    this.display = displayElement;
+    this.alarmListener = alarm => this.handleAlarmFired(alarm);
+
+    chrome.alarms.onAlarm.addListener(this.alarmListener);
+  }
+
+  destroy() {
+    chrome.alarms.onAlarm.removeListener(this.alarmListener);
+  }
+
+  /**
+   * @param {Object} options
+   * @param {string} options.name
+   * @param {number} options.delay
+   * @param {"ms"|"min"} options.delayFormat;
+   * @param {number} options.period;
+   */
+  create(options) {
+    let alarmInfo = {};
+
+    if (options.delayFormat == 'ms') {
+      // specified in milliseconds, use `when` property
+      alarmInfo.when = options.delay;
+    } else {
+      // assume minutes, use `delayInMinutes` property
+      alarmInfo.delayInMinutes = options.delay;
+    }
+
+    if (options.period) {
+      alarmInfo.periodInMinutes = options.period;
+    }
+
+    chrome.alarms.create(options.name, alarmInfo);
+  }
+
+  async clear(name) {
+    return new Promise((resolve, reject) => {
+      chrome.alarms.clear(name, (wasCleared) => {
+        let data = { name, wasCleared };
+        if (wasCleared) {
+          resolve(data);
+        } else {
+          reject(data);
+        }
+      });
+    });
+  }
+
+  clearAll() {
+    chrome.alarm.clearAll((wasCleared) => {
+      // update alarm display to show all have been canceled
+    });
+  }
+
+  handleAlarmFired() {
+
+  }
+}
+
+class ExtensionAlarm extends HTMLElement{
+  static extensionAlarmTemplate = document.createElement('template');
+
+  constructor() {
+    super();
+
+    // Instantiate template
+    let template = ExtensionAlarm.template.content.cloneNode(true);
+
+    this.shadowRoot = this.attachShadow({mode: 'open'});
+    this.shadowRoot.appendChild(template);
+
+    // Store references to dynamically driven UI values
+    this.rootEl = template.querySelector('.alarm-info');
+    this.nameEl = template.querySelector('.alarm__name');
+    this.statusEl = template.querySelector('.alarm__status');
+    this.scheduleEl = template.querySelector('.alarm__schedule');
+    this.periodEl = template.querySelector('.alarm__period');
+  }
+
+  handleAlarmFired() {
+    let isPeriodic = false;
+    if (isPeriodic) return;
+
+    this.rootEl.classList.add('alarm-info--fired');
+  }
+}
+
+ExtensionAlarm.template.innerHTML = `
+<div class="alarm-info">
+  <table class="alarm-info__table">
+    <tr>
+      <th class="alarm-info-label">Alarm Name</th>
+      <td class="alarm__name"></td>
+    </tr>
+    <tr>
+      <th class="alarm-info-label">Status</th>
+      <td class="alarm__status"></td>
+    </tr>
+    <tr>
+      <th class="alarm-info-label">Next Tick</th>
+      <td class="alarm__schedule"></td>
+    </tr>
+    <tr>
+      <th class="alarm-info-label">Period</th>
+      <td class="alarm__period"></td>
+    </tr>
+  </table>
+</div>
+`;
+
+let knownAlarms = new Set();
+
+function cancelAllAlarms() {
+  chrome.alarms.clearAll();
+  display.innerHTML = '';
+}

--- a/api/alarms/lib/alarmManager.js
+++ b/api/alarms/lib/alarmManager.js
@@ -1,0 +1,61 @@
+// Individual alarm UI
+class AlarmManager {
+  constructor(displayElement) {
+    this.display = displayElement;
+    this.alarmListener = alarm => this.handleAlarmFired(alarm);
+
+    chrome.alarms.onAlarm.addListener(this.alarmListener);
+  }
+
+  destroy() {
+    chrome.alarms.onAlarm.removeListener(this.alarmListener);
+  }
+
+  /**
+   * @param {Object} options
+   * @param {string} options.name
+   * @param {number} options.delay
+   * @param {"ms"|"min"} options.delayFormat;
+   * @param {number} options.period;
+   */
+  create(options) {
+    let alarmInfo = {};
+
+    if (options.delayFormat == 'ms') {
+      // specified in milliseconds, use `when` property
+      alarmInfo.when = options.delay;
+    } else {
+      // assume minutes, use `delayInMinutes` property
+      alarmInfo.delayInMinutes = options.delay;
+    }
+
+    if (options.period) {
+      alarmInfo.periodInMinutes = options.period;
+    }
+
+    chrome.alarms.create(options.name, alarmInfo);
+  }
+
+  async clear(name) {
+    return new Promise((resolve, reject) => {
+      chrome.alarms.clear(name, (wasCleared) => {
+        let data = { name, wasCleared };
+        if (wasCleared) {
+          resolve(data);
+        } else {
+          reject(data);
+        }
+      });
+    });
+  }
+
+  clearAll() {
+    chrome.alarm.clearAll((wasCleared) => {
+      // update alarm display to show all have been canceled
+    });
+  }
+
+  handleAlarmFired() {
+
+  }
+}

--- a/api/alarms/manifest.json
+++ b/api/alarms/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "Alarms API Demo",
+  "version": "1.0",
+  "manifest_version": 3,
+  "background": {
+    "service_worker": "bg-wrapper.js"
+  },
+  "permissions": [
+    "alarms"
+  ]
+}


### PR DESCRIPTION
First pass on an example Alarms API demo extension. This demo allows users to create extensions using various combinations of [alarms.create](https://developer.chrome.com/docs/extensions/reference/alarms/#method-create) and to visualize the existing existing alarms.