### PR TITLE
fix #592: broken link to extension examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The directory structure is as follows:
 * [api/](api/) - extensions focused on a single API package
 * (To be added) [howto/](howto/) - extensions that show how to perform a particular task
 * [tutorials/](tutorials/) - multi-step walkthroughs referenced inline in the docs
-* [extensions/](extensions/) - full featured extensions spanning multiple API packages
+* [exmaples/](examples/) - example directory for extensions
 * [apps/](apps/) - deprecated Chrome Apps platform (not listed below)
 * [mv2-archive/](mv2-archive/) - resources for manifest version 2
 


### PR DESCRIPTION
* The link and description of the incorrect README have been corrected.

```markdown
* [exmaples/](examples/) - example directory for extensions
```

* since the change
<img width="613" alt="스크린샷 2021-05-15 오후 12 35 30" src="https://user-images.githubusercontent.com/57028386/118346916-105b7980-b57a-11eb-89ce-013c8977f167.png">
