### PR TITLE
remove extra space and fix typo

### DIFF
--- a/api/action/demo/index.html
+++ b/api/action/demo/index.html
@@ -46,8 +46,7 @@
       <h2>Popup</h2>
 
       <p>This demo's <a href="manifest.json">manifest.json</a> file sets the value of
-      <code>action.default_popup</code> to <code>popups/popup.html</code>. We chan change that
-      behavior at runtime using <a
+      <code>action.default_popup</code> to <code>popups/popup.html</code>. We can change that behavior at runtime using <a
       href="https://developer.chrome.com/docs/extensions/reference/action/#method-setPopup"><code>action.setPopup</code></a>.</p>
 
       <label>


### PR DESCRIPTION
from
```
<code>action.default_popup</code> to <code>popups/popup.html</code>. We chan change that
      behavior at runtime using ....
```

to 
```<code>action.default_popup</code> to <code>popups/popup.html</code>. We can change that behavior at runtime using  ....```
