### PR TITLE
Fix page redder to disregard any chrome internal pages

### DIFF
--- a/examples/page-redder/background.js
+++ b/examples/page-redder/background.js
@@ -3,8 +3,10 @@ function reddenPage() {
 }
 
 chrome.action.onClicked.addListener((tab) => {
-  chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    function: reddenPage
-  });
+  if(!tab.url.includes("chrome://")) {
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      function: reddenPage
+    });
+  }
 });


### PR DESCRIPTION
The page redder example currently affects any tab, regardless of the URL, which can result in errors when this is attempted on an internal Chrome page.

This fix prevents the extension from affecting any Chrome internal page.