### PR TITLE
[focus-mode] Remove "commands" permission

### DIFF
--- a/tutorials/focus-mode/manifest.json
+++ b/tutorials/focus-mode/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Focus Mode",
-  "description": "Enable reading mode on Chrome extension and Chrome web store documentation pages.",
+  "description": "Enable reading mode on Chrome's official Extensions and Chrome Web Store documentation.",
   "version": "1.0",
   "icons": {
     "16": "images/icon-16.png",

--- a/tutorials/focus-mode/manifest.json
+++ b/tutorials/focus-mode/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Focus Mode",
-  "description": "Enable reading mode on extension and web store documentation pages.",
+  "description": "Enable reading mode on Chrome extension and Chrome web store documentation pages.",
   "version": "1.0",
   "icons": {
     "16": "images/icon-16.png",
@@ -20,7 +20,7 @@
       "128": "images/icon-128.png"
     }
   },
-  "permissions": ["scripting", "activeTab", "commands"],
+  "permissions": ["scripting", "activeTab"],
   "commands": {
     "_execute_action": {
       "suggested_key": {


### PR DESCRIPTION
Removing "commands" permission in the manifest of the Focus Mode example, because it's not necessary. 

Thanks @alexherbo2 for pointing this out! :)