### PR TITLE
Fix type of action.default_icon in manifest v3

### DIFF
--- a/examples/bookmarks/manifest.json
+++ b/examples/bookmarks/manifest.json
@@ -8,7 +8,9 @@
   ],
   "action": {
     "default_title": "My Bookmarks",
-    "default_icon": "icon.png",
+    "default_icon": {
+      "32": "icon.png"
+    },
     "default_popup": "popup.html"
   },
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy5Hjn5BDYtngVzsXekpvAPQW7SFpKIM2z/xV4py5XTfOAT5Ln/rEnYfwGNrw6WEZAPo2OsFnSg1ZOpCe7E5NmQVyqbKul9sDwu7wtQ288W8nu2/OoeDfTrfUPSKswTPpA8DbFBLAyYsqLABvg8hpfWRBlKywGSNOAfciJCH13tyUDCMeDWrAbrpdjZDOjTXu7AXLEc5qrAPyLlDisK50THyyCU6BbLttJmIFo3Ymen8UrKkpKsp0ewr5AEDEm4HGgM6/rnAc2Ivpdnt3H3jKv/Ttge9/AkBFvPG0eEgilzkLfydgs1TZp/n4W5Az87LqNH9gN6tJz4z6h+ez3hbmiwIDAQAB"


### PR DESCRIPTION
In manifest v3 action.default_icon is defined as a dictionary of sizes, not a string https://developer.chrome.com/docs/extensions/reference/action/ 