### PR TITLE
Fix code samples for popup script due to Manifest v3 update

### DIFF
--- a/tutorials/getting-started/popup.js
+++ b/tutorials/getting-started/popup.js
@@ -11,7 +11,7 @@ changeColor.addEventListener("click", async () => {
 
   chrome.scripting.executeScript({
     target: { tabId: tab.id },
-    function: setPageBackgroundColor,
+    func: setPageBackgroundColor,
   });
 });
 


### PR DESCRIPTION
According to https://developer.chrome.com/docs/extensions/reference/scripting/#type-ScriptInjection, the property name for function injection has been changed to `func` from `function`. This change update the sample script accordingly.