### PR TITLE
Minor reading-time extension manifest change

### DIFF
--- a/tutorials/reading-time/manifest.json
+++ b/tutorials/reading-time/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Reading Time",
+  "name": "Reading time",
   "version": "1.0",
   "description": "Add the reading time to Chrome Extension documentation articles",
 


### PR DESCRIPTION
Make reading-time extension manifest consistent with tutorial at https://developer.chrome.com/docs/extensions/mv3/getstarted/tut-reading-time/