### PR TITLE
Add offscreen clipboard cookbook example

### DIFF
--- a/cookbook/offscreen-clipboard-write/README.md
+++ b/cookbook/offscreen-clipboard-write/README.md
@@ -1,0 +1,19 @@
+This recipe shows how to write a string to the system clipboard using the [Offscreen API][1].
+
+## Context
+
+As of January 2023, the web platform has to ways to interact with the clipboard: `document.execCommand()` and `navigator.clipboard` (see [MDN's docs][0]). Unfortunately, neither of these APIs are exposed to JavaScript workers. This means that in order for an extension to read from or write values to the system clipboard, the extension _must_ do so in a web page. Enter the Offscreen API. This API was introduced to give extension developers an unobtrusive way to use DOM APIs in the background.
+
+In the future, the Chrome team is planning to add clipboard support directly to extension service workers. As such, this recipe is written to make it as easy as possible to replace `addToClipboard()`'s offscreen document-based implementation with one that directly uses the appropriate clipboard API.
+
+## Running this extension
+
+1. Clone this repository.
+2. Load this directory in Chrome as an [unpacked extension][2].
+3. Open the Extension menu and click the extension named "Offscreen API - Clipboard".
+
+You will now have "Hello, World!" on your system clipboard.
+
+[0]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard
+[1]: https://developer.chrome.com/docs/extensions/reference/offscreen/
+[2]: https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked

--- a/cookbook/offscreen-clipboard-write/background.js
+++ b/cookbook/offscreen-clipboard-write/background.js
@@ -15,20 +15,21 @@
 // The value that will be written to the clipboard.
 const textToCopy = `Hello world!`;
 
-// When the browser action is clicked, `addToClipboard()` will use an offscreen document to write
-// the value of `textToCopy` to the system clipboard.
+// When the browser action is clicked, `addToClipboard()` will use an offscreen
+// document to write the value of `textToCopy` to the system clipboard.
 chrome.action.onClicked.addListener(async () => {
   await addToClipboard(textToCopy);
 });
 
-// Solution 1 - As of Jan 2023, service workers cannot directly interact with the system clipboard.
-// To work around this, we'll create an offscreen document and pass it the data we want to write to
-// the clipboard.
+// Solution 1 - As of Jan 2023, service workers cannot directly interact with
+// the system clipboard. To work around this, we'll create an offscreen document
+// and pass it the data we want to write to the clipboard.
 async function addToClipboard(value) {
-  // This pattern show in this if-else ensures that the offscreen document exists before we try to
-  // send it a message. If we didn't await the `hasDocument()` and `createDocument()` calls, the
-  // `sendMessage()` call could be sent before the offscreen document can register it's
-  // `runtime.onMessage` listener.
+  // This pattern ensures that the offscreen document exists before we try to
+  // send it a message. If we didn't await the `hasDocument()` and
+  // `createDocument()` calls, the `sendMessage()` call could send a message
+  // before the offscreen document can register it's `runtime.onMessage`
+  // listener.
   if (await chrome.offscreen.hasDocument()) {
     console.debug('Offscreen doc already exists.');
   } else {
@@ -41,7 +42,8 @@ async function addToClipboard(value) {
     });
   }
 
-  // Now that are sure we have an offscreen document, we can safely dispatch the message.
+  // Now that are sure we have an offscreen document, we can safely dispatch the
+  // message.
   chrome.runtime.sendMessage({
     type: 'copy-data-to-clipboard',
     target: 'offscreen-doc',

--- a/cookbook/offscreen-clipboard-write/background.js
+++ b/cookbook/offscreen-clipboard-write/background.js
@@ -52,5 +52,5 @@ async function addToClipboard(value) {
 // Solution 2 – Once extension service workers can use the Clipboard API,
 // replace the offscreen document based implementation with something like this.
 async function addToClipboardV2(value) {
-  navigator.clipboard.writeText(value)
+  navigator.clipboard.writeText(value);
 }

--- a/cookbook/offscreen-clipboard-write/background.js
+++ b/cookbook/offscreen-clipboard-write/background.js
@@ -41,7 +41,7 @@ async function addToClipboard(value) {
     });
   }
 
-  // Now that are sure we have an off document, we can safely dispatch the message.
+  // Now that are sure we have an offscreen document, we can safely dispatch the message.
   chrome.runtime.sendMessage({
     type: 'copy-data-to-clipboard',
     target: 'offscreen-doc',

--- a/cookbook/offscreen-clipboard-write/background.js
+++ b/cookbook/offscreen-clipboard-write/background.js
@@ -22,8 +22,9 @@ chrome.action.onClicked.addListener(async () => {
 });
 
 // Solution 1 - As of Jan 2023, service workers cannot directly interact with
-// the system clipboard. To work around this, we'll create an offscreen document
-// and pass it the data we want to write to the clipboard.
+// the system clipboard using either `navigator.clipboard` or
+// `document.execCommand()`. To work around this, we'll create an offscreen
+// document and pass it the data we want to write to the clipboard.
 async function addToClipboard(value) {
   // This pattern ensures that the offscreen document exists before we try to
   // send it a message. If we didn't await the `hasDocument()` and

--- a/cookbook/offscreen-clipboard-write/background.js
+++ b/cookbook/offscreen-clipboard-write/background.js
@@ -1,0 +1,53 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(dotproto): Add more comments explaining this code.
+
+const textToCopy = `Hello world!`;
+
+chrome.action.onClicked.addListener(async () => {
+  await addToClipboard(textToCopy);
+});
+
+// Solution 1 - Current solution for extension service workers
+
+async function addToClipboard(value) {
+  if (await chrome.offscreen.hasDocument()) {
+    console.debug('Offscreen doc already exists');
+  } else {
+    console.debug('Creating a new offscreen document.');
+
+    // TODO(dotproto): Follow up with eng to make sure that the doc's
+    // `runtime.onMessage` listener will be registered before the
+    // `createDocument()` call resolves. If not, we'll need to rewrite this to
+    // guarantee the correct order of operations.
+    await chrome.offscreen.createDocument({
+      url: 'offscreen.html',
+      reasons: [chrome.offscreen.Reason.CLIPBOARD],
+      justification: 'Write text to the clipboard.',
+    });
+  }
+
+  chrome.runtime.sendMessage({
+    type: 'copy-data-to-clipboard',
+    target: 'offscreen-doc',
+    data: value,
+  });
+}
+
+// Solution 2 – Only use this when
+
+async function addToClipboardV2(value) {
+  navigator.clipboard.copyText(value)
+}

--- a/cookbook/offscreen-clipboard-write/background.js
+++ b/cookbook/offscreen-clipboard-write/background.js
@@ -20,7 +20,9 @@ chrome.action.onClicked.addListener(async () => {
   await addToClipboard(textToCopy);
 });
 
-// Solution 1 - Current solution for extension service workers
+// Solution 1 - As of Jan 2023, service workers cannot directly interact with
+// the system clipboard. To work around this, we'll create an offscreen document
+// and pass it the data we want to write to the clipboard.
 
 async function addToClipboard(value) {
   if (await chrome.offscreen.hasDocument()) {
@@ -46,7 +48,8 @@ async function addToClipboard(value) {
   });
 }
 
-// Solution 2 – Only use this when
+// Solution 2 – Once extension service workers can use the Clipboard API,
+// replace the offscreen document based implementation with this.
 
 async function addToClipboardV2(value) {
   navigator.clipboard.copyText(value)

--- a/cookbook/offscreen-clipboard-write/manifest.json
+++ b/cookbook/offscreen-clipboard-write/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Offscreen API - Clipboard",
+  "version": "1.0",
+  "manifest_version": 3,
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {},
+  "permissions": [
+    "offscreen",
+    "clipboardWrite"
+  ]
+}

--- a/cookbook/offscreen-clipboard-write/offscreen.html
+++ b/cookbook/offscreen-clipboard-write/offscreen.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
-<textarea id="text" type="text"></textarea>
+<textarea id="text"></textarea>
 <script src="offscreen.js""></script>

--- a/cookbook/offscreen-clipboard-write/offscreen.html
+++ b/cookbook/offscreen-clipboard-write/offscreen.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<input id="text" type="text">
+<script src="offscreen.js""></script>

--- a/cookbook/offscreen-clipboard-write/offscreen.html
+++ b/cookbook/offscreen-clipboard-write/offscreen.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
-<input id="text" type="text">
+<textarea id="text" type="text"></textarea>
 <script src="offscreen.js""></script>

--- a/cookbook/offscreen-clipboard-write/offscreen.js
+++ b/cookbook/offscreen-clipboard-write/offscreen.js
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(dotproto): Add more comments explaining this code.
+// Once the message has been posted from the service worker, checks are made to confirm the message type and target before proceeding. 
+// This is so that the module can easily be adapted into existing workflows where secondary uses for the document (or alternate offscreen documents) might be implemented.
 
 chrome.runtime.onMessage.addListener(handleMessages);
 
@@ -27,6 +28,8 @@ async function handleMessages(message) {
     handleClipboardWrite(message.data);
   }
 }
+
+// The handleClipboardWrite function makes use of a DOM functionality API (document), which is currently impossible from inside a service worker. 
 
 async function handleClipboardWrite(data) {
   // Return early if we received the wrong kind of data.

--- a/cookbook/offscreen-clipboard-write/offscreen.js
+++ b/cookbook/offscreen-clipboard-write/offscreen.js
@@ -17,34 +17,46 @@
 // workflows where secondary uses for the document (or alternate offscreen documents) might be
 // implemented.
 
+// Registering this listener when the script is first executed ensures that the offscreen document
+// will be able to receive messages when the promise returned by `offscreen.createDocument()`
+// resolves.
 chrome.runtime.onMessage.addListener(handleMessages);
 
+// This function performs basic filtering and error checking on messages before dispatching the
+// message to a more specific message handler.
 async function handleMessages(message) {
   // Return early if this message isn't meant for the offscreen document.
   if (message.target !== 'offscreen-doc') {
     return;
   }
 
-  // Return early if we got the wrong type of message.
-  if (message.type === 'copy-data-to-clipboard') {
-    handleClipboardWrite(message.data);
+  // Dispatch the message to an appropriate handler.
+  switch (message.type) {
+    case 'copy-data-to-clipboard':
+      handleClipboardWrite(message.data);
+      break;
+    default:
+      console.warn(`Unexpected message type received: '${message.type}'.`);
   }
 }
 
-// The `handleClipboardWrite()` function makes use of a web platform API (`document`) that is not
-// exposed to extension service workers.
-
+// Use the offscreen document's `document` interface to write a new value ot the system clipboard
 async function handleClipboardWrite(data) {
-  // Return early if we received the wrong kind of data.
+  // Error if we received the wrong kind of data.
   if (typeof data !== 'string') {
     throw new TypeError(`Value provided must be a 'string', got '${typeof data}'.`);
     return;
   }
 
   // Write data the clipboard.
+
+  // `document.execCommand('copy')` works against the user's selected in a web page. As such, we
+  // need to insert the updated text into the document and select it before it can be added to the
+  // clipboard.
   textEl.value = data;
   textEl.select();
   document.execCommand('copy');
 }
 
+// This textarea is used to easily modify and select it's text value.
 let textEl = document.querySelector('#text');

--- a/cookbook/offscreen-clipboard-write/offscreen.js
+++ b/cookbook/offscreen-clipboard-write/offscreen.js
@@ -57,7 +57,6 @@ async function handleClipboardWrite(data) {
   // Error if we received the wrong kind of data.
   if (typeof data !== 'string') {
     throw new TypeError(`Value provided must be a 'string', got '${typeof data}'.`);
-    return;
   }
 
   // `document.execCommand('copy')` works against the user's selection in a web

--- a/cookbook/offscreen-clipboard-write/offscreen.js
+++ b/cookbook/offscreen-clipboard-write/offscreen.js
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Once the message has been posted from the service worker, checks are made to confirm the message
-// type and target before proceeding. This is so that the module can easily be adapted into existing
-// workflows where secondary uses for the document (or alternate offscreen documents) might be
-// implemented.
+// Once the message has been posted from the service worker, checks are made to
+// confirm the message type and target before proceeding. This is so that the
+// module can easily be adapted into existing workflows where secondary uses for
+// the document (or alternate offscreen documents) might be implemented.
 
-// Registering this listener when the script is first executed ensures that the offscreen document
-// will be able to receive messages when the promise returned by `offscreen.createDocument()`
-// resolves.
+// Registering this listener when the script is first executed ensures that the
+// offscreen document will be able to receive messages when the promise returned
+// by `offscreen.createDocument()` resolves.
 chrome.runtime.onMessage.addListener(handleMessages);
 
-// This function performs basic filtering and error checking on messages before dispatching the
+// This function performs basic filtering and error checking on messages before
+// dispatching the
 // message to a more specific message handler.
 async function handleMessages(message) {
   // Return early if this message isn't meant for the offscreen document.
@@ -40,7 +41,18 @@ async function handleMessages(message) {
   }
 }
 
-// Use the offscreen document's `document` interface to write a new value to the system clipboard
+
+// We use a <textarea> element for two main reasons:
+//  1. preserve the formatting of multiline text,
+//  2. select the node's content using this element's `.select()` method.
+let textEl = document.querySelector('#text');
+
+// Use the offscreen document's `document` interface to write a new value to the
+// system clipboard.
+//
+// At the time this demo was created (Jan 2023) the `navigator.clipboard` API
+// requires that the window is focused, but offscreen documents cannot be
+// focused. As such, we have to fall back to `document.execCommand()`.
 async function handleClipboardWrite(data) {
   // Error if we received the wrong kind of data.
   if (typeof data !== 'string') {
@@ -48,15 +60,10 @@ async function handleClipboardWrite(data) {
     return;
   }
 
-  // Write data the clipboard.
-
-  // `document.execCommand('copy')` works against the user's selection in a web page. As such, we
-  // need to insert the updated text into the document and select it before it can be added to the
-  // clipboard.
+  // `document.execCommand('copy')` works against the user's selection in a web
+  // page. As such, we must insert the string we want to copy to the web page
+  // and to select that content in the page before calling `execCommand()`.
   textEl.value = data;
   textEl.select();
   document.execCommand('copy');
 }
-
-// This textarea is used to easily modify and select it's text value.
-let textEl = document.querySelector('#text');

--- a/cookbook/offscreen-clipboard-write/offscreen.js
+++ b/cookbook/offscreen-clipboard-write/offscreen.js
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Once the message has been posted from the service worker, checks are made to confirm the message type and target before proceeding. 
-// This is so that the module can easily be adapted into existing workflows where secondary uses for the document (or alternate offscreen documents) might be implemented.
+// Once the message has been posted from the service worker, checks are made to confirm the message
+// type and target before proceeding. This is so that the module can easily be adapted into existing
+// workflows where secondary uses for the document (or alternate offscreen documents) might be
+// implemented.
 
 chrome.runtime.onMessage.addListener(handleMessages);
 
@@ -29,12 +31,13 @@ async function handleMessages(message) {
   }
 }
 
-// The handleClipboardWrite function makes use of a DOM functionality API (document), which is currently impossible from inside a service worker. 
+// The `handleClipboardWrite()` function makes use of a web platform API (`document`) that is not
+// exposed to extension service workers.
 
 async function handleClipboardWrite(data) {
   // Return early if we received the wrong kind of data.
   if (typeof data !== 'string') {
-    console.debug(`Unexpected data value. Expected a 'string' value but received '${typeof data}'. Aborting.`)
+    throw new TypeError(`Value provided must be a 'string', got '${typeof data}'.`);
     return;
   }
 

--- a/cookbook/offscreen-clipboard-write/offscreen.js
+++ b/cookbook/offscreen-clipboard-write/offscreen.js
@@ -1,0 +1,44 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(dotproto): Add more comments explaining this code.
+
+chrome.runtime.onMessage.addListener(handleMessages);
+
+async function handleMessages(message) {
+  // Return early if this message isn't meant for the offscreen document.
+  if (message.target !== 'offscreen-doc') {
+    return;
+  }
+
+  // Return early if we got the wrong type of message.
+  if (message.type === 'copy-data-to-clipboard') {
+    handleClipboardWrite(message.data);
+  }
+}
+
+async function handleClipboardWrite(data) {
+  // Return early if we received the wrong kind of data.
+  if (typeof data !== 'string') {
+    console.debug(`Unexpected data value. Expected a 'string' value but received '${typeof data}'. Aborting.`)
+    return;
+  }
+
+  // Write data the clipboard.
+  textEl.value = data;
+  textEl.select();
+  document.execCommand('copy');
+}
+
+let textEl = document.querySelector('#text');

--- a/cookbook/offscreen-clipboard-write/offscreen.js
+++ b/cookbook/offscreen-clipboard-write/offscreen.js
@@ -40,7 +40,7 @@ async function handleMessages(message) {
   }
 }
 
-// Use the offscreen document's `document` interface to write a new value ot the system clipboard
+// Use the offscreen document's `document` interface to write a new value to the system clipboard
 async function handleClipboardWrite(data) {
   // Error if we received the wrong kind of data.
   if (typeof data !== 'string') {
@@ -50,7 +50,7 @@ async function handleClipboardWrite(data) {
 
   // Write data the clipboard.
 
-  // `document.execCommand('copy')` works against the user's selected in a web page. As such, we
+  // `document.execCommand('copy')` works against the user's selection in a web page. As such, we
   // need to insert the updated text into the document and select it before it can be added to the
   // clipboard.
   textEl.value = data;


### PR DESCRIPTION
This PR contains a functional demo of how to interact with the system clipboard using the [Offscreen API](https://developer.chrome.com/docs/extensions/reference/offscreen) and web APIs (namely [`document.execCommand()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand), [MDN guide](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard)).