### PR TITLE
Fix typo in focus-mode ext description

### DIFF
--- a/tutorials/focus-mode/manifest.json
+++ b/tutorials/focus-mode/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Focus Mode",
-  "description": "Enable reading mode on Chrome's official Extensions and Chrome Web Store documentation.",
+  "description": "Enable focus mode on Chrome's official Extensions and Chrome Web Store documentation.",
   "version": "1.0",
   "icons": {
     "16": "images/icon-16.png",


### PR DESCRIPTION
The description mentions it enables "reading mode", but based on the tutorial, I believe this is meant to say "focus mode"?