### PR TITLE
Fix #4994: Minor issue with Focus-Mode Extension Tutorials

### DIFF
--- a/tutorials/focus-mode/manifest.json
+++ b/tutorials/focus-mode/manifest.json
@@ -24,8 +24,8 @@
   "commands": {
     "_execute_action": {
       "suggested_key": {
-        "default": "Ctrl+U",
-        "mac": "Command+U"
+        "default": "Ctrl+B",
+        "mac": "Command+B"
       }
     }
   }


### PR DESCRIPTION
Fixes [#4994](https://github.com/GoogleChrome/developer.chrome.com/issues/4994)

Changes proposed in this pull request:

- changes are related to [PR](https://github.com/GoogleChrome/developer.chrome.com/pull/5004)
- Updates the keyboard shortcut (link) in [focus-mode extension example](https://github.com/GoogleChrome/chrome-extensions-samples/blob/b5c62b1c6fd96d58eb6b301658557f787283b78d/tutorials/focus-mode/manifest.json#L4)  to be in sync with [docs](https://github.com/GoogleChrome/developer.chrome.com/blob/ee5272a42af61da906bf9de941e9eac0838208eb/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md?plain=1#L42)