### PR TITLE
add sample for catifier that replaces every jpg image on web by anoth…

### DIFF
--- a/functional-samples/sample.catifier/manifest.json
+++ b/functional-samples/sample.catifier/manifest.json
@@ -1,0 +1,16 @@
+{
+    "name": "Catifier",
+    "version": "1.0",
+    "description": "Replace every image by a cat's image in a website you visit",
+    "permissions": ["declarativeNetRequest"],
+    "host_permissions": ["*://*/*"],
+    "declarative_net_request": {
+        "rule_resources": [{
+          "id": "ruleset_1",
+          "enabled": true,
+          "path": "rules.json"
+        }]
+      },
+  
+    "manifest_version": 3
+  }

--- a/functional-samples/sample.catifier/rules.json
+++ b/functional-samples/sample.catifier/rules.json
@@ -1,0 +1,14 @@
+[
+    {
+      "id": 1,
+      "priority": 100,
+      "action": { "type": "redirect", "redirect": { "url": "https://i.chzbgr.com/completestore/12/8/23/S__rxG9hIUK4sNuMdTIY9w2.jpg" } },
+      "condition": {"urlFilter": "*.jpeg", "resourceType": ["image"]} 
+    },
+    {
+       "id": 2,
+       "priority": 100,
+       "action": { "type": "redirect", "redirect": { "url": "https://i.chzbgr.com/completestore/12/8/23/S__rxG9hIUK4sNuMdTIY9w2.jpg" } },
+       "condition": {"urlFilter": "*.jpg", "resourceType": ["image"]} 
+    }
+  ]


### PR DESCRIPTION
update catifier to mv3, using `declarativeNetRequest` instead of  deprecated `declarativeWebRequest`.