### PR TITLE
Ignore packed extension from allstar checks.

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,3 @@
+# Ignore reason: Packed extension for demo purposes.
+ignorePaths:
+  - _archive/mv2/api/permissions/extension-questions.crx


### PR DESCRIPTION
Adds an ignore file to avoid [allstar](https://github.com/ossf/allstar/) warnings for the presence of a packed extension.

Fixes #789 