### PR TITLE
add eslint-config-prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "Apache 2.0",
       "devDependencies": {
-        "eslint": "^8.34.0",
+        "eslint": "8.34.0",
         "eslint-config-prettier": "8.6.0",
         "eslint-plugin-import": "2.27.5",
         "eslint-plugin-prettier": "4.2.1",
-        "husky": "^8.0.0",
-        "lint-staged": "^13.1.2",
+        "husky": "8.0.0",
+        "lint-staged": "13.1.2",
         "prettier": "2.8.4"
       }
     },
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.0.tgz",
+      "integrity": "sha512-4qbE/5dzNDNxFEkX9MNRPKl5+omTXQzdILCUWiqG/lWIAioiM5vln265/l6I2Zx8gpW8l1ukZwGQeCFbBZ6+6w==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
@@ -3906,9 +3906,9 @@
       "dev": true
     },
     "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.0.tgz",
+      "integrity": "sha512-4qbE/5dzNDNxFEkX9MNRPKl5+omTXQzdILCUWiqG/lWIAioiM5vln265/l6I2Zx8gpW8l1ukZwGQeCFbBZ6+6w==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   },
   "homepage": "https://github.com/GoogleChrome/chrome-extensions-samples#readme",
   "devDependencies": {
-    "eslint": "^8.34.0",
+    "eslint": "8.34.0",
     "eslint-config-prettier": "8.6.0",
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-prettier": "4.2.1",
-    "husky": "^8.0.0",
-    "lint-staged": "^13.1.2",
+    "husky": "8.0.0",
+    "lint-staged": "13.1.2",
     "prettier": "2.8.4"
   },
   "lint-staged": {


### PR DESCRIPTION
currently...

```
$ npx lint-staged                                                                    
✔ Preparing lint-staged...                                      
❯ Running tasks for staged files...                             
  ❯ package.json — 3 files                                      
    ❯ **/*.js — 1 file                                          
      ✖ npx eslint --fix [FAILED]                                                                                               
    ❯ **/*.{md,html} — 2 files                                                                                                  
      ✖ npx prettier --write                                                                                                                                                                                                                                    
↓ Skipped because of errors from tasks. [SKIPPED]                                                                                                                                                                                                               
✔ Reverting to original state because of errors...                                                                              
✔ Cleaning up temporary files...                                                                                                
                                                                
✖ npx eslint --fix:                                   
                                                                
Oops! Something went wrong! :(                                                                                                  
                                                                
ESLint: 8.36.0                                                                                                                  
                                                                                                                                
ESLint couldn't find the config "prettier" to extend from. Please check that the name of the config is correct.                                                                                                                                                 
                                                                                                                                                                                                                                                                
The config "prettier" was referenced from the config file in "/Users/patrickkettner/projects/chrome-extensions-samples/.eslintrc.js".
                                                                
If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.
```


this pr fixes that