### PR TITLE
Update README.md

### DIFF
--- a/functional-samples/cookbook.offscreen-clipboard-write/README.md
+++ b/functional-samples/cookbook.offscreen-clipboard-write/README.md
@@ -2,7 +2,7 @@ This recipe shows how to write a string to the system clipboard using the [Offsc
 
 ## Context
 
-As of January 2023, the web platform has to ways to interact with the clipboard: `document.execCommand()` and `navigator.clipboard` (see [MDN's docs][0]). Unfortunately, neither of these APIs are exposed to JavaScript workers. This means that in order for an extension to read from or write values to the system clipboard, the extension _must_ do so in a web page. Enter the Offscreen API. This API was introduced to give extension developers an unobtrusive way to use DOM APIs in the background.
+As of January 2023, the web platform has two ways to interact with the clipboard: `document.execCommand()` and `navigator.clipboard` (see [MDN's docs][0]). Unfortunately, neither of these APIs are exposed to JavaScript workers. This means that in order for an extension to read from or write values to the system clipboard, the extension _must_ do so in a web page. Enter the Offscreen API. This API was introduced to give extension developers an unobtrusive way to use DOM APIs in the background.
 
 In the future, the Chrome team is planning to add clipboard support directly to extension service workers. As such, this recipe is written to make it as easy as possible to replace `addToClipboard()`'s offscreen document-based implementation with one that directly uses the appropriate clipboard API.
 


### PR DESCRIPTION
spell checking issue
changed  "to" => "two " ,
with accordance to context