### PR TITLE
Resolved the broken links in README.md file

### DIFF
--- a/api-samples/action/README.md
+++ b/api-samples/action/README.md
@@ -2,7 +2,7 @@
 
 This sample demonstrates the use of Action API which changes the badge text,icon,hover text or popup page depending on the user's choice or action.
 
-[chrome.action_API_Link]('https://developer.chrome.com/docs/extensions/reference/action/')
+[API Link](https://developer.chrome.com/docs/extensions/reference/action/)
 
 ## Overview
 
@@ -16,4 +16,4 @@ This sample demonstrates the Action API by allowing the user to perform the belo
 
 ## Implementation Notes
 
-The user can set values to implement above functionalities from [here]('../demo/index.html')
+The user can set values to implement above functionalities from [here](demo/index.html)


### PR DESCRIPTION
This PR fixes the broken links in README.md file highlighted below.

BEFORE:
![image](https://github.com/GoogleChrome/chrome-extensions-samples/assets/253690/b2cd627f-6c9c-4dbf-91f7-6b710254d374)
