### PR TITLE
Fix rule creation in sample.dnr-rule-manager when no rule exists

### DIFF
--- a/functional-samples/sample.dnr-rule-manager/manager.js
+++ b/functional-samples/sample.dnr-rule-manager/manager.js
@@ -5,7 +5,7 @@ const viewRuleButton = document.getElementById('viewRuleButton');
 
 async function getNextRuleId() {
   const rules = await chrome.declarativeNetRequest.getDynamicRules();
-  return Math.max(...rules.map((rule) => rule.id)) + 1;
+  return Math.max(0, ...rules.map((rule) => rule.id)) + 1;
 }
 
 async function refresh() {


### PR DESCRIPTION
The `functional-samples/sample.dnr-rule-manager` example allows the user to add and remove `chrome.declarativeNetRequest` rules on demand from the extension's options page.

Rules require to have a unique `id`, so the extension fetches the list of all the currently defined rules, takes the max and adds 1.

When no rule is defined, this results in `Math.max(...[]) + 1` => `Math.max() + 1` => `-Infinity + 1` (see [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max#return_value)) => `-Infinity` and since the `id` should be an integer and not a number, the extension throws an error.

Ensuring that `0` is always a parameter of `Math.max` should solve the problem.