### PR TITLE
Fix: use let to prevent reassignment error for sandbox result

### DIFF
--- a/api-samples/sandbox/sandbox/sandbox.html
+++ b/api-samples/sandbox/sandbox/sandbox.html
@@ -57,8 +57,8 @@ limitations under the License.
       // Set up message event handler:
       window.addEventListener('message', function (event) {
         const command = event.data.command;
-        const template = templates[event.data.templateName],
-          result = 'invalid request';
+        const template = templates[event.data.templateName];
+        let result = 'invalid request';
 
         // if we don't know the templateName requested, return an error message
         if (template) {


### PR DESCRIPTION
In the sandbox/sandbox example, a variable `result` is created as a const, but it's attempted to be reassigned later in the code.  This changeset just changes the `result` variable to be a reassignable variable instead.

<img width="1506" alt="Screenshot 2024-01-09 at 18 32 15" src="https://github.com/GoogleChrome/chrome-extensions-samples/assets/2421042/68bc282f-f084-4a91-b431-a2da767d93a1">
