### PR TITLE
Update chrome.privacy API sample

### DIFF
--- a/api-samples/privacy/README.md
+++ b/api-samples/privacy/README.md
@@ -4,7 +4,7 @@ This sample demonstrates using `chrome.privacy.services` to get and set privacy 
 
 ## Overview
 
-The service worker sets the default value for autofill using `chrome.privacy.services.autofillCreditCardEnabled.set()` when the extension is installed. Whenever the action button is clicked, the extension will toggle the current autofill setting of `autofillCreditCardEnabled` and update the extension badge.
+The service worker sets the default value for autofill using `chrome.privacy.services.autofillCreditCardEnabled.set()` when the extension is installed. Whenever the action button is clicked, the extension toggles the current autofill setting of `autofillCreditCardEnabled` and updates the extension badge.
 
 ## Running this extension
 

--- a/api-samples/privacy/README.md
+++ b/api-samples/privacy/README.md
@@ -4,10 +4,10 @@ This sample demonstrates using `chrome.privacy.services` to get and set privacy 
 
 ## Overview
 
-The service worker sets the default value for autofill using `chrome.privacy.services.autofillEnabled.set()` when the extension is installed. Whenever a page is loaded, or when the action button is clicked, the extension will display the current autofill setting of `autofillAddressEnabled` by updating the extension badge.
+The service worker sets the default value for autofill using `chrome.privacy.services.autofillCreditCardEnabled.set()` when the extension is installed. Whenever the action button is clicked, the extension will toggle the current autofill setting of `autofillCreditCardEnabled` and update the extension badge.
 
 ## Running this extension
 
 1. Clone this repository.
 2. Load this directory in Chrome as an [unpacked extension](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked).
-3. Pin the extension to the taskbar and either click the action button or load a webpage.
+3. Pin the extension to the taskbar and click the action button.

--- a/api-samples/privacy/service-worker.js
+++ b/api-samples/privacy/service-worker.js
@@ -13,31 +13,35 @@
 // limitations under the License.
 
 chrome.runtime.onInstalled.addListener(() => {
-  // Set default value for Autofill Enabled
-  chrome.privacy.services.autofillEnabled.set({ value: true });
+  // Set default value for credit card autofill enabled
+  chrome.privacy.services.autofillCreditCardEnabled.set({ value: true });
+  updateAutofillEnabledStatus();
 });
 
 chrome.runtime.onStartup.addListener(() => {
   updateAutofillEnabledStatus();
 });
 
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.status === 'complete' && tab.active) {
-    updateAutofillEnabledStatus();
+async function updateAutofillEnabledStatus(toggle = false) {
+  const details = await chrome.privacy.services.autofillCreditCardEnabled.get(
+    {}
+  );
+  let autofillEnabled = details.value;
+
+  if (toggle) {
+    autofillEnabled = !autofillEnabled;
+    await chrome.privacy.services.autofillCreditCardEnabled.set({
+      value: autofillEnabled
+    });
   }
-});
 
-function updateAutofillEnabledStatus() {
-  chrome.privacy.services.autofillEnabled.get({}, (details) => {
-    const autofillEnabled = details.value;
-    const badgeText = autofillEnabled ? 'Enabled' : 'Disabled';
-    const badgeColor = autofillEnabled ? '#00FF00' : '#FF0000';
+  const badgeText = autofillEnabled ? 'Enabled' : 'Disabled';
+  const badgeColor = autofillEnabled ? '#00FF00' : '#FF0000';
 
-    chrome.action.setBadgeText({ text: badgeText });
-    chrome.action.setBadgeBackgroundColor({ color: badgeColor });
-  });
+  chrome.action.setBadgeText({ text: badgeText });
+  chrome.action.setBadgeBackgroundColor({ color: badgeColor });
 }
 
 chrome.action.onClicked.addListener(() => {
-  updateAutofillEnabledStatus();
+  updateAutofillEnabledStatus(true);
 });


### PR DESCRIPTION
Updates the API sample for chrome.privacy to avoid using the deprecated autofillEnabled property and to behave in a way which is more useful. In particular, you can now easily toggle the setting by clicking the extension icon.

See https://issuetracker.google.com/issues/311072505 for more context.