### PR TITLE
Update popup.js

### DIFF
--- a/functional-samples/tutorial.tabs-manager/popup.js
+++ b/functional-samples/tutorial.tabs-manager/popup.js
@@ -28,7 +28,7 @@ const elements = new Set();
 for (const tab of tabs) {
   const element = template.content.firstElementChild.cloneNode(true);
 
-  const title = tab.title.split('-')[0].trim();
+  const title = tab.title.split('|')[0].trim();
   const pathname = new URL(tab.url).pathname.slice('/docs'.length);
 
   element.querySelector('.title').textContent = title;


### PR DESCRIPTION
The separator used in docs title has been updated from [`-`](https://web.archive.org/web/20230510130047/https://developer.chrome.com/docs/extensions/mv3/getstarted/tut-tabs-manager/) to [`|`](https://web.archive.org/web/20231208180535/https://developer.chrome.com/docs/extensions/get-started/tutorial/popup-tabs-manager)


