### PR TITLE
Update side panel examples to use action icon

### DIFF
--- a/functional-samples/cookbook.sidepanel-global/manifest.json
+++ b/functional-samples/cookbook.sidepanel-global/manifest.json
@@ -8,6 +8,12 @@
     "48": "images/icon-48.png",
     "128": "images/icon-128.png"
   },
+  "background": {
+    "service_worker": "service-worker.js"
+  },
+  "action": {
+    "default_title": "Click to open panel"
+  },
   "side_panel": {
     "default_path": "sidepanel.html"
   },

--- a/functional-samples/cookbook.sidepanel-global/service-worker.js
+++ b/functional-samples/cookbook.sidepanel-global/service-worker.js
@@ -1,0 +1,3 @@
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+});

--- a/functional-samples/cookbook.sidepanel-multiple/manifest.json
+++ b/functional-samples/cookbook.sidepanel-multiple/manifest.json
@@ -6,6 +6,9 @@
   "background": {
     "service_worker": "service-worker.js"
   },
+  "action": {
+    "default_title": "Click to open panel"
+  },
   "icons": {
     "16": "images/icon-16.png",
     "48": "images/icon-48.png",

--- a/functional-samples/cookbook.sidepanel-multiple/service-worker.js
+++ b/functional-samples/cookbook.sidepanel-multiple/service-worker.js
@@ -17,6 +17,7 @@ const mainPage = 'sidepanels/main-sp.html';
 
 chrome.runtime.onInstalled.addListener(() => {
   chrome.sidePanel.setOptions({ path: welcomePage });
+  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
 });
 
 chrome.tabs.onActivated.addListener(async ({ tabId }) => {


### PR DESCRIPTION
We recently updated the side panel UI in Chrome - there is no longer a global side panel icon and developers need to provide an explicit way for their side panel to be opened. This PR updates the samples accordingly. Docs to follow.