### PR TITLE
Remove notification permission from push cookbook sample

### DIFF
--- a/functional-samples/cookbook.push/README.md
+++ b/functional-samples/cookbook.push/README.md
@@ -9,7 +9,6 @@ By calling a method in the sample and using an external push server website we c
 ## Running this extension
 
 1. Clone this repository.
-1. Ensure your operating system allows your browser to show desktop notification. For [MacOS](https://support.apple.com/guide/mac-help/change-notifications-settings-mh40583/mac) this, for Google Chrome, requires "Google Chrome" and "Google Chrome Helper (Alerts)" to be allowed. Although we won't see a notification with this sample, this ensures that the lack of a notification is not from the inability to show a desktop notification.
 1. Go to the [web push test server](https://web-push-codelab.glitch.me/) and copy the “Public Key” to the `APPLICATION_SERVER_PUBLIC_KEY` variable in background.js.
 1. Load this directory in Chrome as an [unpacked extension](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked).
 1. Click “service worker (Inactive)” on the extension to load DevTools for background.js

--- a/functional-samples/cookbook.push/README.md
+++ b/functional-samples/cookbook.push/README.md
@@ -4,12 +4,12 @@ This sample demonstrates using the [Push API](https://developer.mozilla.org/en-U
 
 ## Overview
 
-By calling a method in the sample and using an external push server website we can simulate an extension receiving a push message where it is required to emit a notification and where it can bypass that requirement (`userVisibleOnly = false`).
+By calling a method in the sample and using an external push server website we can simulate an extension receiving a push message where it is not required to emit a notification by setting (`userVisibleOnly = false`) on registration.
 
 ## Running this extension
 
 1. Clone this repository.
-1. Ensure your operating system allows your browser to show desktop notification. For [MacOS](https://support.apple.com/guide/mac-help/change-notifications-settings-mh40583/mac) this, for Google Chrome, requires "Google Chrome" and "Google Chrome Helper (Alerts)" to be allowed.
+1. Ensure your operating system allows your browser to show desktop notification. For [MacOS](https://support.apple.com/guide/mac-help/change-notifications-settings-mh40583/mac) this, for Google Chrome, requires "Google Chrome" and "Google Chrome Helper (Alerts)" to be allowed. Although we won't see a notification with this sample, this ensures that the lack of a notification is not from the inability to show a desktop notification.
 1. Go to the [web push test server](https://web-push-codelab.glitch.me/) and copy the “Public Key” to the `APPLICATION_SERVER_PUBLIC_KEY` variable in background.js.
 1. Load this directory in Chrome as an [unpacked extension](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked).
 1. Click “service worker (Inactive)” on the extension to load DevTools for background.js

--- a/functional-samples/cookbook.push/README.md
+++ b/functional-samples/cookbook.push/README.md
@@ -8,6 +8,8 @@ By calling a method in the sample and using an external push server website we c
 
 ## Running this extension
 
+Note: This sample requires Chrome 132+. Before Chrome 132, the same code works with the additional requirement of the `notification` extension permission.
+
 1. Clone this repository.
 1. Go to the [web push test server](https://web-push-codelab.glitch.me/) and copy the “Public Key” to the `APPLICATION_SERVER_PUBLIC_KEY` variable in background.js.
 1. Load this directory in Chrome as an [unpacked extension](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked).

--- a/functional-samples/cookbook.push/background.js
+++ b/functional-samples/cookbook.push/background.js
@@ -57,6 +57,10 @@ self.addEventListener('push', function (event) {
 
   // Before `userVisibleOnly` could be passed as false we would have to show a
   // notification at this point, but now we no longer have to.
+
+  // If the extension chooses to show a notification message then the
+  // notification permission must be granted (in manifest or at runtime)
+  // or the attempt will be denied.
 });
 
 // Helper method for converting the server key to an array that is passed

--- a/functional-samples/cookbook.push/background.js
+++ b/functional-samples/cookbook.push/background.js
@@ -56,11 +56,8 @@ self.addEventListener('push', function (event) {
   );
 
   // Before `userVisibleOnly` could be passed as false we would have to show a
-  // notification at this point, but now we no longer have to.
-
-  // If the extension chooses to show a notification message then the
-  // notification permission must be granted (in manifest or at runtime)
-  // or the attempt will be denied.
+  // notification at this point (or if we didn't the browser would show a
+  // generic notification), but now we no longer have to.
 });
 
 // Helper method for converting the server key to an array that is passed

--- a/functional-samples/cookbook.push/manifest.json
+++ b/functional-samples/cookbook.push/manifest.json
@@ -1,9 +1,8 @@
 {
-  "name": "Service worker with push notification",
+  "name": "Service worker with silent push message",
   "version": "1.0",
   "manifest_version": 3,
   "background": {
     "service_worker": "background.js"
-  },
-  "permissions": ["notifications"]
+  }
 }


### PR DESCRIPTION
As of [M132] this requirement is no longer necessary (unless the extension chooses to show a notification).

[M132]: https://chromiumdash.appspot.com/commit/ed68ac786e9a276ef2b627b7e21cf0d20cc6d798