### PR TITLE
Add Notification Permission in Manifest for Web Push Extension

### DIFF
--- a/functional-samples/cookbook.push/manifest.json
+++ b/functional-samples/cookbook.push/manifest.json
@@ -1,8 +1,9 @@
 {
-  "name": "Service worker with silent push message",
+  "name": "Web Push Extension",
   "version": "1.0",
   "manifest_version": 3,
   "background": {
     "service_worker": "background.js"
-  }
+  },
+  "permissions": ["notifications"]
 }


### PR DESCRIPTION

- Updated manifest.json to include "notifications" permission.
- Enables the extension to display push notifications to users.
- Required for handling web push events in background.js.

This update ensures the extension can send notifications as part of the web push functionality.