### PR TITLE
Update api-samples/bookmarks

### DIFF
--- a/api-samples/bookmarks/popup.js
+++ b/api-samples/bookmarks/popup.js
@@ -42,7 +42,6 @@ function displayBookmarks(nodes, parentNode) {
 function addBookmark() {
   chrome.bookmarks.create(
     {
-      parentId: '1',
       title: 'Google',
       url: 'https://www.google.com'
     },


### PR DESCRIPTION
The extension currently assumes that a bookmark folder with ID "1" exists, and that children can be created below it. This is not guaranteed to be true.

Update the chrome.bookmarks.create() call to instead leave parentId unspecified, which will select the "Other bookmarks" folder.