### PR TITLE
Disambiguate account/local folders sample bookmarks extension

### DIFF
--- a/functional-samples/sample.bookmarks/popup.js
+++ b/functional-samples/sample.bookmarks/popup.js
@@ -48,9 +48,9 @@ function dumpNode(bookmarkNode, query) {
     // folderType is set for top-level folders in the tree, and not for child
     // folders. In Chrome versions prior to milestone 134, folderType is never
     // set.
-    let title_text = bookmarkNode.title
+    let title_text = bookmarkNode.title;
     if (bookmarkNode.folderType) {
-      title_text += bookmarkNode.syncing ? " (Account)" : " (Local)";
+      title_text += bookmarkNode.syncing ? ' (Account)' : ' (Local)';
     }
     anchor.text(title_text);
 

--- a/functional-samples/sample.bookmarks/popup.js
+++ b/functional-samples/sample.bookmarks/popup.js
@@ -40,7 +40,15 @@ function dumpNode(bookmarkNode, query) {
 
     const anchor = $('<a>');
     anchor.attr('href', bookmarkNode.url);
-    anchor.text(bookmarkNode.title);
+
+    // Chrome may have multiple top-level folder nodes with the same title. To
+    // disambiguate them, include a suffix depending on the value of the
+    // syncing property.
+    let title_text = bookmarkNode.title
+    if (bookmarkNode.folderType) {
+      title_text += bookmarkNode.syncing ? " (Account)" : " (Local)";
+    }
+    anchor.text(title_text);
 
     /*
      * When clicking on a bookmark in the extension, a new tab is fired with

--- a/functional-samples/sample.bookmarks/popup.js
+++ b/functional-samples/sample.bookmarks/popup.js
@@ -44,6 +44,10 @@ function dumpNode(bookmarkNode, query) {
     // Chrome may have multiple top-level folder nodes with the same title. To
     // disambiguate them, include a suffix depending on the value of the
     // syncing property.
+    //
+    // folderType is set for top-level folders in the tree, and not for child
+    // folders. In Chrome versions prior to milestone 134, folderType is never
+    // set.
     let title_text = bookmarkNode.title
     if (bookmarkNode.folderType) {
       title_text += bookmarkNode.syncing ? " (Account)" : " (Local)";


### PR DESCRIPTION
This shows how to use the recently-added `folderType` and `syncing` bookmark node properties to distinguish top-level folders that may existing in both syncing and non-syncing storages.