### PR TITLE
Fix linter error and run on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: CI
-on: push
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/api-samples/identity/main.js
+++ b/api-samples/identity/main.js
@@ -1,6 +1,6 @@
 chrome.action.onClicked.addListener(() => {
   chrome.tabs.create({
     active: true,
-    url: "index.html"
-  })
-})
+    url: 'index.html'
+  });
+});


### PR DESCRIPTION
Fixes a linter error in the `identity` API sample, and updates the linter to run on all PRs going forward.