### PR TITLE
Add getProfileUserInfo example to sample identity extension

### DIFF
--- a/api-samples/identity/identity.js
+++ b/api-samples/identity/identity.js
@@ -41,6 +41,7 @@ function onLoad() {
   function getEmail() {
     chrome.identity.getProfileUserInfo({accountStatus: chrome.identity.AccountStatus.ANY })
       .then((profile_user_info) => {
+        displayOutput('chrome.identity.getProfileUserInfo() returned: ' + JSON.stringify(profile_user_info));
         document.getElementById('email-info').innerText = profile_user_info.email;
       });
   }

--- a/api-samples/identity/identity.js
+++ b/api-samples/identity/identity.js
@@ -39,10 +39,15 @@ function onLoad() {
   // This uses the chrome.identity.getProfileUserInfo API, and does not require
   // an auth token.
   function getEmail() {
-    chrome.identity.getProfileUserInfo({accountStatus: chrome.identity.AccountStatus.ANY })
+    chrome.identity
+      .getProfileUserInfo({ accountStatus: chrome.identity.AccountStatus.ANY })
       .then((profile_user_info) => {
-        displayOutput('chrome.identity.getProfileUserInfo() returned: ' + JSON.stringify(profile_user_info));
-        document.getElementById('email-info').innerText = profile_user_info.email;
+        displayOutput(
+          'chrome.identity.getProfileUserInfo() returned: ' +
+            JSON.stringify(profile_user_info)
+        );
+        document.getElementById('email-info').innerText =
+          profile_user_info.email;
       });
   }
 

--- a/api-samples/identity/identity.js
+++ b/api-samples/identity/identity.js
@@ -7,6 +7,8 @@ function onLoad() {
 
   let state = STATE_START;
 
+  document.querySelector('#get-email').addEventListener('click', getEmail);
+
   const signin_button = document.querySelector('#signin');
   signin_button.addEventListener('click', interactiveSignIn);
 
@@ -31,6 +33,16 @@ function onLoad() {
 
   function enableButton(button) {
     button.removeAttribute('disabled');
+  }
+
+  // Gets the email address for the primary account.
+  // This uses the chrome.identity.getProfileUserInfo API, and does not require
+  // an auth token.
+  function getEmail() {
+    chrome.identity.getProfileUserInfo({accountStatus: chrome.identity.AccountStatus.ANY })
+      .then((profile_user_info) => {
+        document.getElementById('email-info').innerText = profile_user_info.email;
+      });
   }
 
   function changeState(newState) {
@@ -101,6 +113,8 @@ function onLoad() {
     }
   }
 
+  // This fetches user information over the network, providing an access token
+  // scoped to this extension.
   function getUserInfo(interactive) {
     // See https://developers.google.com/identity/openid-connect/openid-connect#obtaininguserprofileinformation
     fetchWithAuth(

--- a/api-samples/identity/index.html
+++ b/api-samples/identity/index.html
@@ -15,9 +15,9 @@
       <hr>
     </div>
     <div class="flows">
-      <h2>Get primary account email address</h2>
+      <h2>Query local Chrome account information</h2>
       <div class="flow">
-        <button id="get-email">Get email address</button>
+        <button id="get-email">Get primary account email address</button>
         <div id="email-info"></div>
       </div>
       <h2>OAuth on Google properties</h2>

--- a/api-samples/identity/index.html
+++ b/api-samples/identity/index.html
@@ -9,12 +9,17 @@
       <h1>Identity API</h1>
       <div class="links">
         Learn more:
-          <a target="_blank" href="https://developer.chrome.com/docs/extensions/reference/api/identity">API docs</a>
-          <a id="_open_snippets" href="https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/identity">Source</a>
+        <a target="_blank" href="https://developer.chrome.com/docs/extensions/reference/api/identity">API docs</a>
+        <a id="_open_snippets" href="https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/identity">Source</a>
       </div>
       <hr>
     </div>
     <div class="flows">
+      <h2>Get primary account email address</h2>
+      <div class="flow">
+        <button id="get-email">Get email address</button>
+        <div id="email-info"></div>
+      </div>
       <h2>OAuth on Google properties</h2>
       <div class="flow">
         <button id="signin">Sign in</button>
@@ -23,8 +28,8 @@
         <div id="user_info"></div>
       </div>
     </div>
-   <div class="log">
+    <div class="log">
       <textarea id="__logarea" disabled></textarea>
-   </div>
+    </div>
   </body>
 </html>

--- a/api-samples/identity/manifest.json
+++ b/api-samples/identity/manifest.json
@@ -7,7 +7,7 @@
   "background": {
     "service_worker": "main.js"
   },
-  "permissions": ["identity"],
+  "permissions": ["identity", "identity.email"],
   "oauth2": {
     // client_id below is specific to the application key. Follow the
     // documentation to obtain one for your app.


### PR DESCRIPTION
This adds an example for the [getProfileUserInfo()](https://developer.chrome.com/docs/extensions/reference/api/identity#method-getProfileUserInfo) method, printing the primary account's email address.