### PR TITLE
Replaced clearbit API (deprecated) (#1453)

### DIFF
--- a/_archive/mv2/extensions/optional_permissions/logic.js
+++ b/_archive/mv2/extensions/optional_permissions/logic.js
@@ -28,7 +28,7 @@ function createTop(){chrome.topSites.get(function(topSites) {
     let hostname = (new URL(site.url)).hostname;
     let image = document.createElement('img');
     image.title = site.title;
-    image.src = 'https://logo.clearbit.com/' + hostname;
+    image.src = 'https://www.google.com/s2/favicons?sz=128&domain_url=' + hostname;
     url.appendChild(image);
     div.appendChild(url);
     div.appendChild(tooltip);

--- a/functional-samples/sample.optional_permissions/newtab.js
+++ b/functional-samples/sample.optional_permissions/newtab.js
@@ -36,7 +36,7 @@ const createTop = () => {
       const hostname = new URL(site.url).hostname;
       const image = document.createElement('img');
       image.title = site.title;
-      image.src = 'https://logo.clearbit.com/' + hostname;
+      image.src = 'https://www.google.com/s2/favicons?sz=128&domain_url=' + hostname;
       url.appendChild(image);
       div.appendChild(url);
       div.appendChild(tooltip);


### PR DESCRIPTION
Replaced the usage of Clearbit’s Free Logo API (logo.clearbit.com), which is Being Discontinued (#1453)
with Google's favicon snatcher