### PR TITLE
Move sw-tips tutorial to use chrome.dev

### DIFF
--- a/functional-samples/tutorial.quick-api-reference/manifest.json
+++ b/functional-samples/tutorial.quick-api-reference/manifest.json
@@ -16,7 +16,6 @@
     "keyword": "api"
   },
   "permissions": ["alarms", "storage"],
-  "host_permissions": ["https://extension-tips.glitch.me/*"],
   "content_scripts": [
     {
       "matches": ["https://developer.chrome.com/docs/extensions/reference/*"],

--- a/functional-samples/tutorial.quick-api-reference/sw-tips.js
+++ b/functional-samples/tutorial.quick-api-reference/sw-tips.js
@@ -2,7 +2,7 @@ console.log('sw-tips.js');
 
 // Fetch tip & save in storage
 const updateTip = async () => {
-  const response = await fetch('https://extension-tips.glitch.me/tips.json');
+  const response = await fetch('https://chrome.dev/f/extension_tips/');
   const tips = await response.json();
   const randomIndex = Math.floor(Math.random() * tips.length);
   return chrome.storage.local.set({ tip: tips[randomIndex] });


### PR DESCRIPTION
Moves from the Glitch URL to chrome.dev, and removes the host permissions as we now set CORS headers.