### PR TITLE
Use `<number>.<number>` format for Google Analytics client ID

### DIFF
--- a/functional-samples/tutorial.google-analytics/scripts/google-analytics.js
+++ b/functional-samples/tutorial.google-analytics/scripts/google-analytics.js
@@ -15,11 +15,11 @@ class Analytics {
   }
 
   getRandomId() {
-    const digits = "123456789".split("");
-    let result = "";
+    const digits = '123456789'.split('');
+    let result = '';
 
     for (let i = 0; i < 10; i++) {
-      result += digits[Math.floor(Math.random() * 9)]
+      result += digits[Math.floor(Math.random() * 9)];
     }
 
     return result;


### PR DESCRIPTION
With the `ENFORCE_RECOMMENDATIONS` [validation behavior](https://developers.google.com/analytics/devguides/collection/protocol/ga4/validating-events?client_type=firebase#send_events_for_validation), Google Analytics warns about client IDs not in the `<number>.<number>` format.

This is not an issue in practice - that recommendation is for compatibility with existing client IDs and events are still processed with a client ID in any format. Additionally, the validation is not enabled by default.

However, this PR updates our sample code to use a consistent ID regardless to reduce noise if the validation is enabled. We use a random ID concatenated with a UNIX timestamp to match other GA client libraries.