### PR TITLE
security: harden permissions for ai.gemini-on-device-alt-texter

### DIFF
--- a/functional-samples/ai.gemini-on-device-alt-texter/manifest.json
+++ b/functional-samples/ai.gemini-on-device-alt-texter/manifest.json
@@ -3,8 +3,7 @@
   "name": "Alt Texter",
   "version": "1.0",
   "description": "Generates alt text for images using the Gemini Nano Prompt API.",
-  "permissions": ["contextMenus", "clipboardWrite"],
-  "host_permissions": ["<all_urls>"],
+  "permissions": ["contextMenus", "clipboardWrite", "activeTab"],
   "minimum_chrome_version": "138",
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
The `ai.gemini-on-device-alt-texter` sample currently requests `<all_urls>` host permissions. 

Following the Principle of Least Privilege, I've replaced this with `activeTab`. This change provides necessary access to the current page only upon user interaction (via context menu), significantly reducing the extension's attack surface while maintaining full functionality.