### PR TITLE
security: replace insecure innerHTML with safe DOM manipulation

### DIFF
--- a/api-samples/printing/printers.js
+++ b/api-samples/printing/printers.js
@@ -87,7 +87,7 @@ function onCancelButtonClicked(jobId) {
 
 function createButton(label, onClicked) {
   const button = document.createElement('button');
-  button.innerHTML = label;
+  button.textContent = label;
   button.onclick = onClicked;
   return button;
 }

--- a/api-samples/tabs/inspector/window_and_tabs_manager.js
+++ b/api-samples/tabs/inspector/window_and_tabs_manager.js
@@ -31,7 +31,7 @@ async function loadWindowList() {
   }
 
   const output = document.getElementById('windowList');
-  output.innerHTML = '';
+  output.replaceChildren();
 
   for (let window of windowList) {
     const windowItem = document.importNode(windowTemplate, true).children[0];


### PR DESCRIPTION
Several samples currently use `.innerHTML` for DOM manipulation where `textContent` or `replaceChildren()` is more appropriate. 

Updated the following to follow XSS prevention best practices:
1.  **api-samples/printing/printers.js:** Replaced `.innerHTML = label` with `.textContent = label` in the `createButton` utility to mitigate potential script injection.
2.  **api-samples/tabs/inspector/window_and_tabs_manager.js:** Switched to `.replaceChildren()` for more secure and performant DOM clearing.

These changes ensure the samples align with modern security standards for Chrome Extensions.