### PR TITLE
Fix side panel sample tab path setup

### DIFF
--- a/functional-samples/cookbook.sidepanel-open/content-script.js
+++ b/functional-samples/cookbook.sidepanel-open/content-script.js
@@ -2,7 +2,12 @@ const button = new DOMParser().parseFromString(
   '<button>Click to open side panel</button>',
   'text/html'
 ).body.firstElementChild;
+button.disabled = true;
 button.addEventListener('click', function () {
   chrome.runtime.sendMessage({ type: 'open_side_panel' });
 });
 document.body.append(button);
+
+chrome.runtime.sendMessage({ type: 'enable_tab_side_panel' }, () => {
+  button.disabled = false;
+});

--- a/functional-samples/cookbook.sidepanel-open/script.js
+++ b/functional-samples/cookbook.sidepanel-open/script.js
@@ -5,12 +5,13 @@ const [tab] = await chrome.tabs.query({
 });
 
 const tabId = tab.id;
+await chrome.sidePanel.setOptions({
+  tabId,
+  path: 'sidepanel-tab.html',
+  enabled: true
+});
+
 const button = document.getElementById('openSidePanel');
 button.addEventListener('click', async () => {
   await chrome.sidePanel.open({ tabId });
-  await chrome.sidePanel.setOptions({
-    tabId,
-    path: 'sidepanel-tab.html',
-    enabled: true
-  });
 });

--- a/functional-samples/cookbook.sidepanel-open/service-worker.js
+++ b/functional-samples/cookbook.sidepanel-open/service-worker.js
@@ -28,17 +28,28 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   }
 });
 
-chrome.runtime.onMessage.addListener((message, sender) => {
+async function enableTabSidePanel(tabId) {
+  await chrome.sidePanel.setOptions({
+    tabId,
+    path: 'sidepanel-tab.html',
+    enabled: true
+  });
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // The callback for runtime.onMessage must return falsy if we're not sending a response
-  (async () => {
-    if (message.type === 'open_side_panel') {
-      // This will open a tab-specific side panel only on the current tab.
-      await chrome.sidePanel.open({ tabId: sender.tab.id });
-      await chrome.sidePanel.setOptions({
-        tabId: sender.tab.id,
-        path: 'sidepanel-tab.html',
-        enabled: true
-      });
-    }
-  })();
+  const tabId = sender.tab?.id;
+  if (!tabId) return;
+
+  if (message.type === 'enable_tab_side_panel') {
+    enableTabSidePanel(tabId)
+      .catch((error) => console.error(error))
+      .finally(sendResponse);
+    return true;
+  }
+
+  if (message.type === 'open_side_panel') {
+    // This will open a tab-specific side panel only on the current tab.
+    chrome.sidePanel.open({ tabId }).catch((error) => console.error(error));
+  }
 });


### PR DESCRIPTION
## Summary
- Configure the tab-specific side panel path before the extension page button can open the panel.
- Have the content script request tab-specific setup before enabling its injected button.
- Keep the click-triggered path focused on `chrome.sidePanel.open()` so the first click opens `sidepanel-tab.html`.

Fixes #1477.

## Testing
- `npx eslint functional-samples/cookbook.sidepanel-open/content-script.js functional-samples/cookbook.sidepanel-open/script.js functional-samples/cookbook.sidepanel-open/service-worker.js`