### PR TITLE
Add userScripts.execute sample

### DIFF
--- a/api-samples/userScripts/README.md
+++ b/api-samples/userScripts/README.md
@@ -1,6 +1,6 @@
 # chrome.userScripts API
 
-This sample demonstrates using the [`chrome.userScripts`](https://developer.chrome.com/docs/extensions/reference/scripting/) API to inject JavaScript into web pages.
+This sample demonstrates using the [`chrome.userScripts`](https://developer.chrome.com/docs/extensions/reference/api/userScripts/) API to inject JavaScript into web pages.
 
 ## Overview
 
@@ -14,16 +14,18 @@ Clicking this extension's action icon opens an options page.
 2. Load this directory in Chrome as an [unpacked extension](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked).
 3. Click the extension's action icon to open the options page.
 4. Once a user script has been configured, visit https://example.com/.
+5. Use the **Execute** button to run one-off code in an open https://example.com/ tab.
 
 ## Features
 
 This sample allows you to inject the following:
 
 - Files
-- Arbitrary code
+- Registered arbitrary code
+- One-off arbitrary code with `chrome.userScripts.execute()`
 
 ## Implementation Notes
 
-The User Scripts API requires users to enabled developer mode. We check for this by attempting to access `chrome.userScripts`, which throws an error on property access if it is disabled.
+The User Scripts API requires users to enable developer mode or the Allow User Scripts extension toggle. We check for this before registering or executing scripts.
 
-When a change is made on the options page, use the `chrome.userScripts` API to update the user script registration.
+When a change is made on the options page, use the `chrome.userScripts` API to update the user script registration. The **Execute** button uses `chrome.userScripts.execute()` to inject code into an existing https://example.com/ tab without registering it.

--- a/api-samples/userScripts/manifest.json
+++ b/api-samples/userScripts/manifest.json
@@ -2,7 +2,7 @@
   "name": "User Scripts API Demo",
   "version": "1.0",
   "manifest_version": 3,
-  "minimum_chrome_version": "120",
+  "minimum_chrome_version": "135",
   "description": "Uses the chrome.userScripts API to inject JavaScript into web pages.",
   "background": {
     "service_worker": "sw.js"

--- a/api-samples/userScripts/options.css
+++ b/api-samples/userScripts/options.css
@@ -50,6 +50,14 @@ button {
   margin: 20px 0;
 }
 
+#execute-result {
+  min-height: 1.2em;
+}
+
+#execute-result[data-error] {
+  color: #b00020;
+}
+
 /* Hide custom script textarea by default */
 #custom-script-wrapper {
   display: none;

--- a/api-samples/userScripts/options.html
+++ b/api-samples/userScripts/options.html
@@ -25,8 +25,8 @@ limitations under the License.
   <body>
     <div id="warning">
       <p>
-        ⚠️ To use the User Scripts API, you need to first enable developer mode
-        at <b>chrome://extensions</b>.
+        To use the User Scripts API, enable developer mode or the Allow User
+        Scripts toggle at <b>chrome://extensions</b>.
       </p>
       <a href="">Reload</a>
     </div>
@@ -51,6 +51,20 @@ limitations under the License.
         ></textarea>
       </div>
       <button type="button" id="save-button">Save & Enable</button>
+      <hr />
+      <h2>Run once</h2>
+      <p>
+        Open https://example.com/ in a tab, then execute code without
+        registering it.
+      </p>
+      <textarea
+        name="execute-script"
+        draggable="false"
+        rows="8"
+        placeholder="document.body.style.outline = '4px solid #1a73e8';"
+      ></textarea>
+      <button type="button" id="execute-button">Execute</button>
+      <p id="execute-result" role="status"></p>
     </form>
   </body>
 </html>

--- a/api-samples/userScripts/options.js
+++ b/api-samples/userScripts/options.js
@@ -13,13 +13,23 @@
 // limitations under the License.
 
 const USER_SCRIPT_ID = 'default';
+const EXAMPLE_MATCH_PATTERN = 'https://example.com/*';
+const EXAMPLE_ORIGIN = 'https://example.com/';
 const SAVE_BUTTON_ID = 'save-button';
+const EXECUTE_BUTTON_ID = 'execute-button';
+const EXECUTE_RESULT_ID = 'execute-result';
 
 const FORM_ID = 'settings-form';
 const FORM = document.getElementById(FORM_ID);
 
 const TYPE_INPUT_NAME = 'type';
 const SCRIPT_TEXTAREA_NAME = 'custom-script';
+const EXECUTE_TEXTAREA_NAME = 'execute-script';
+const DEFAULT_EXECUTE_SCRIPT = [
+  "document.body.style.outline = '4px solid #1a73e8';",
+  "document.body.dataset.userScriptsExecute = 'true';",
+  "'done';"
+].join('\n');
 
 /**
  * Checks if the user has developer mode enabled, which is required to use the
@@ -29,8 +39,12 @@ const SCRIPT_TEXTAREA_NAME = 'custom-script';
  */
 function isUserScriptsAvailable() {
   try {
-    // Property access which throws if developer mode is not enabled.
-    chrome.userScripts;
+    // Property access throws in older Chrome versions when developer mode is
+    // disabled, and newer versions expose the API as undefined until the user
+    // enables the Allow User Scripts toggle.
+    if (!chrome.userScripts) throw new Error();
+    document.getElementById('warning').style.display = 'none';
+    FORM.style.display = 'block';
     return true;
   } catch {
     // Not available, so hide UI and show error.
@@ -40,18 +54,44 @@ function isUserScriptsAvailable() {
   }
 }
 
+function getScriptSource(type, script) {
+  return type === 'file' ? [{ file: 'user-script.js' }] : [{ code: script }];
+}
+
+function setExecuteResult(message, isError = false) {
+  const result = document.getElementById(EXECUTE_RESULT_ID);
+  result.textContent = message;
+  result.toggleAttribute('data-error', isError);
+}
+
+async function getTargetTab() {
+  const [activeTab] = await chrome.tabs.query({
+    active: true,
+    currentWindow: true
+  });
+
+  if (activeTab?.id && activeTab.url?.startsWith(EXAMPLE_ORIGIN)) {
+    return activeTab;
+  }
+
+  const [exampleTab] = await chrome.tabs.query({ url: EXAMPLE_MATCH_PATTERN });
+  return exampleTab;
+}
+
 async function updateUi() {
   if (!isUserScriptsAvailable()) return;
 
   // Access settings from storage with default values.
-  const { type, script } = await chrome.storage.local.get({
+  const { type, script, executeScript } = await chrome.storage.local.get({
     type: 'file',
-    script: "alert('hi');"
+    script: "alert('hi');",
+    executeScript: DEFAULT_EXECUTE_SCRIPT
   });
 
   // Update UI with current values.
   FORM.elements[TYPE_INPUT_NAME].value = type;
   FORM.elements[SCRIPT_TEXTAREA_NAME].value = script;
+  FORM.elements[EXECUTE_TEXTAREA_NAME].value = executeScript;
 }
 
 async function onSave() {
@@ -62,7 +102,7 @@ async function onSave() {
   const script = FORM.elements[SCRIPT_TEXTAREA_NAME].value;
 
   // Save to storage.
-  chrome.storage.local.set({
+  await chrome.storage.local.set({
     type,
     script
   });
@@ -77,7 +117,7 @@ async function onSave() {
       {
         id: USER_SCRIPT_ID,
         matches: ['https://example.com/*'],
-        js: type === 'file' ? [{ file: 'user-script.js' }] : [{ code: script }]
+        js: getScriptSource(type, script)
       }
     ]);
   } else {
@@ -86,9 +126,50 @@ async function onSave() {
       {
         id: USER_SCRIPT_ID,
         matches: ['https://example.com/*'],
-        js: type === 'file' ? [{ file: 'user-script.js' }] : [{ code: script }]
+        js: getScriptSource(type, script)
       }
     ]);
+  }
+}
+
+async function onExecute() {
+  if (!isUserScriptsAvailable()) return;
+
+  const executeScript = FORM.elements[EXECUTE_TEXTAREA_NAME].value.trim();
+  if (!executeScript) {
+    setExecuteResult('Enter script text to execute.', true);
+    return;
+  }
+
+  await chrome.storage.local.set({ executeScript });
+
+  const tab = await getTargetTab();
+  if (!tab?.id) {
+    setExecuteResult('Open https://example.com/ in a tab first.', true);
+    return;
+  }
+
+  try {
+    const results = await chrome.userScripts.execute({
+      target: { tabId: tab.id },
+      js: [{ code: executeScript }]
+    });
+    const errors = results
+      .filter((result) => result.error)
+      .map((result) => result.error);
+
+    if (errors.length > 0) {
+      setExecuteResult(errors.join('\n'), true);
+      return;
+    }
+
+    const result = results.find(({ result }) => result !== undefined);
+    const resultText = result
+      ? ` Result: ${JSON.stringify(result.result)}`
+      : '';
+    setExecuteResult(`Executed in ${results.length} frame(s).${resultText}`);
+  } catch (error) {
+    setExecuteResult(error.message, true);
   }
 }
 
@@ -98,3 +179,4 @@ chrome.storage.local.onChanged.addListener(updateUi);
 
 // Register listener for save button click.
 document.getElementById(SAVE_BUTTON_ID).addEventListener('click', onSave);
+document.getElementById(EXECUTE_BUTTON_ID).addEventListener('click', onExecute);


### PR DESCRIPTION
## Problem
The `userScripts` sample only showed persistent registration/update flows, while #1482 asks for sample coverage of `chrome.userScripts.execute()` for dynamic one-off code.

## Root cause
`userScripts.execute()` was added after the original sample and needs a `UserScriptInjection` target plus Chrome 135+, so the existing Chrome 120 sample never demonstrated it.

## Solution
- Raise the sample minimum Chrome version to 135.
- Add a Run once section that executes code in an open `https://example.com/` tab with `chrome.userScripts.execute()` and displays the injection result or error.
- Reuse the existing script source construction for registered file/custom code.
- Update README instructions and fix the API docs link.

## Tests run
- `npx eslint --no-warn-ignored api-samples/userScripts/options.js --quiet`
- `npx prettier --check api-samples/userScripts/manifest.json api-samples/userScripts/options.html api-samples/userScripts/options.js api-samples/userScripts/options.css api-samples/userScripts/README.md`
- `git diff --check HEAD~1..HEAD`
- Node VM smoke test for `options.js` registration and execute payload

Fixes #1482