### PR TITLE
Fix tab-specific side panel open order

### DIFF
--- a/functional-samples/cookbook.sidepanel-open/script.js
+++ b/functional-samples/cookbook.sidepanel-open/script.js
@@ -7,10 +7,10 @@ const [tab] = await chrome.tabs.query({
 const tabId = tab.id;
 const button = document.getElementById('openSidePanel');
 button.addEventListener('click', async () => {
-  await chrome.sidePanel.open({ tabId });
   await chrome.sidePanel.setOptions({
     tabId,
     path: 'sidepanel-tab.html',
     enabled: true
   });
+  await chrome.sidePanel.open({ tabId });
 });

--- a/functional-samples/cookbook.sidepanel-open/service-worker.js
+++ b/functional-samples/cookbook.sidepanel-open/service-worker.js
@@ -33,12 +33,12 @@ chrome.runtime.onMessage.addListener((message, sender) => {
   (async () => {
     if (message.type === 'open_side_panel') {
       // This will open a tab-specific side panel only on the current tab.
-      await chrome.sidePanel.open({ tabId: sender.tab.id });
       await chrome.sidePanel.setOptions({
         tabId: sender.tab.id,
         path: 'sidepanel-tab.html',
         enabled: true
       });
+      await chrome.sidePanel.open({ tabId: sender.tab.id });
     }
   })();
 });


### PR DESCRIPTION
## Problem
The side panel cookbook sample can open the global side panel when a user tries the tab-specific path, matching the report in #1179.

## Root cause
The sample called `chrome.sidePanel.open({ tabId })` before assigning the tab-specific `sidepanel-tab.html` path. Because the manifest has a global `default_path`, Chrome can open the global panel before the tab-specific options are applied.

## Solution
Set the tab-specific side panel options first, then call `chrome.sidePanel.open({ tabId })`, in both the extension page flow and the content-script message flow.

## Tests run
- `npx eslint --no-warn-ignored functional-samples/cookbook.sidepanel-open/script.js functional-samples/cookbook.sidepanel-open/service-worker.js --quiet`
- `npx prettier --check functional-samples/cookbook.sidepanel-open/script.js functional-samples/cookbook.sidepanel-open/service-worker.js`
- `git diff --check HEAD~1..HEAD`
- Node smoke check that `setOptions` precedes `open` in both tab-specific entry points

Fixes #1179