### PR TITLE
Update global search sample region handling

### DIFF
--- a/api-samples/contextMenus/global_context_search/README.md
+++ b/api-samples/contextMenus/global_context_search/README.md
@@ -1,10 +1,10 @@
 # chrome.contextMenus
 
-This sample demonstrates the `chrome.contextMenus` API by letting a user switch between searching different countries' versions of Google via a `contextMenu`.
+This sample demonstrates the `chrome.contextMenus` API by letting a user restrict Google Search results to pages from different countries via a `contextMenu`.
 
 ## Overview
 
-The extension uses `chrome.contextMenus.create()` to populate the context menu with locale options based on an options menu in the popup. A `chrome.contextMenus.onClicked.addListener()` event will open a specific locale's Google homepage when one of the extension's context menu options are clicked.
+The extension uses `chrome.contextMenus.create()` to populate the context menu with country options based on an options menu in the popup. A `chrome.contextMenus.onClicked.addListener()` event opens Google Search with a `cr=countryXX` query parameter when one of the extension's context menu options is clicked.
 
 ## Running this extension
 

--- a/api-samples/contextMenus/global_context_search/background.js
+++ b/api-samples/contextMenus/global_context_search/background.js
@@ -4,14 +4,14 @@
 
 // When you specify "type": "module" in the manifest background,
 // you can include the service worker as an ES Module,
-import { tldLocales } from './locales.js';
+import { countryLocales } from './locales.js';
 
 // Add a listener to create the initial context menu items,
 // context menu items only need to be created at runtime.onInstalled
 chrome.runtime.onInstalled.addListener(async () => {
-  for (const [tld, locale] of Object.entries(tldLocales)) {
+  for (const [countryCode, locale] of Object.entries(countryLocales)) {
     chrome.contextMenus.create({
-      id: tld,
+      id: countryCode,
       title: locale,
       type: 'normal',
       contexts: ['selection']
@@ -21,36 +21,37 @@ chrome.runtime.onInstalled.addListener(async () => {
 
 // Open a new search tab when the user clicks a context menu
 chrome.contextMenus.onClicked.addListener((item, tab) => {
-  const tld = item.menuItemId;
-  const url = new URL(`https://google.${tld}/search`);
+  const countryCode = item.menuItemId;
+  const url = new URL('https://www.google.com/search');
   url.searchParams.set('q', item.selectionText);
+  url.searchParams.set('cr', `country${countryCode}`);
   chrome.tabs.create({ url: url.href, index: tab.index + 1 });
 });
 
-// Add or removes the locale from context menu
+// Add or removes the locale from the context menu
 // when the user checks or unchecks the locale in the popup
-chrome.storage.onChanged.addListener(({ enabledTlds }) => {
-  if (typeof enabledTlds === 'undefined') return;
+chrome.storage.onChanged.addListener(({ enabledCountries }) => {
+  if (typeof enabledCountries === 'undefined') return;
 
-  const allTlds = Object.keys(tldLocales);
-  const currentTlds = new Set(enabledTlds.newValue);
-  const oldTlds = new Set(enabledTlds.oldValue ?? allTlds);
-  const changes = allTlds.map((tld) => ({
-    tld,
-    added: currentTlds.has(tld) && !oldTlds.has(tld),
-    removed: !currentTlds.has(tld) && oldTlds.has(tld)
+  const allCountries = Object.keys(countryLocales);
+  const currentCountries = new Set(enabledCountries.newValue);
+  const oldCountries = new Set(enabledCountries.oldValue ?? allCountries);
+  const changes = allCountries.map((countryCode) => ({
+    countryCode,
+    added: currentCountries.has(countryCode) && !oldCountries.has(countryCode),
+    removed: !currentCountries.has(countryCode) && oldCountries.has(countryCode)
   }));
 
-  for (const { tld, added, removed } of changes) {
+  for (const { countryCode, added, removed } of changes) {
     if (added) {
       chrome.contextMenus.create({
-        id: tld,
-        title: tldLocales[tld],
+        id: countryCode,
+        title: countryLocales[countryCode],
         type: 'normal',
         contexts: ['selection']
       });
     } else if (removed) {
-      chrome.contextMenus.remove(tld);
+      chrome.contextMenus.remove(countryCode);
     }
   }
 });

--- a/api-samples/contextMenus/global_context_search/locales.js
+++ b/api-samples/contextMenus/global_context_search/locales.js
@@ -2,18 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TLD: top level domain; the "com" in "google.com"
-export const tldLocales = {
-  'com.au': 'Australia',
-  'com.br': 'Brazil',
-  ca: 'Canada',
-  cn: 'China',
-  fr: 'France',
-  it: 'Italy',
-  'co.in': 'India',
-  'co.jp': 'Japan',
-  'com.ms': 'Mexico',
-  ru: 'Russia',
-  'co.za': 'South Africa',
-  'co.uk': 'United Kingdom'
+// Google Search country restrict suffixes used with the "cr" query parameter.
+export const countryLocales = {
+  AU: 'Australia',
+  BR: 'Brazil',
+  CA: 'Canada',
+  CN: 'China',
+  FR: 'France',
+  IT: 'Italy',
+  IN: 'India',
+  JP: 'Japan',
+  MX: 'Mexico',
+  RU: 'Russia',
+  ZA: 'South Africa',
+  UK: 'United Kingdom'
 };

--- a/api-samples/contextMenus/global_context_search/manifest.json
+++ b/api-samples/contextMenus/global_context_search/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Global Google Search",
-  "description": "Uses the context menu to search a different country's Google",
+  "name": "Regional Google Search",
+  "description": "Uses the context menu to restrict Google Search results by country",
   "version": "1.1",
   "manifest_version": 3,
   "permissions": ["contextMenus", "storage"],

--- a/api-samples/contextMenus/global_context_search/popup.html
+++ b/api-samples/contextMenus/global_context_search/popup.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>Global Context Search</title>
+    <title>Regional Context Search</title>
     <style>
       body {
         min-width: 300px;
@@ -16,8 +16,8 @@
   </head>
 
   <body>
-    <h2>Global Google Search</h2>
-    <h3>Countries</h3>
+    <h2>Regional Google Search</h2>
+    <h3>Restrict results to</h3>
     <form id="form"></form>
     <script src="popup.js" type="module"></script>
   </body>

--- a/api-samples/contextMenus/global_context_search/popup.js
+++ b/api-samples/contextMenus/global_context_search/popup.js
@@ -2,22 +2,21 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TLD: top level domain; the "com" in "google.com"
-import { tldLocales } from './locales.js';
+import { countryLocales } from './locales.js';
 
 createForm().catch(console.error);
 
 async function createForm() {
-  const { enabledTlds = Object.keys(tldLocales) } =
-    await chrome.storage.sync.get('enabledTlds');
-  const checked = new Set(enabledTlds);
+  const { enabledCountries = Object.keys(countryLocales) } =
+    await chrome.storage.sync.get('enabledCountries');
+  const checked = new Set(enabledCountries);
 
   const form = document.getElementById('form');
-  for (const [tld, locale] of Object.entries(tldLocales)) {
+  for (const [countryCode, locale] of Object.entries(countryLocales)) {
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
-    checkbox.checked = checked.has(tld);
-    checkbox.name = tld;
+    checkbox.checked = checked.has(countryCode);
+    checkbox.name = countryCode;
     checkbox.addEventListener('click', (event) => {
       handleCheckboxClick(event).catch(console.error);
     });
@@ -35,15 +34,15 @@ async function createForm() {
 
 async function handleCheckboxClick(event) {
   const checkbox = event.target;
-  const tld = checkbox.name;
+  const countryCode = checkbox.name;
   const enabled = checkbox.checked;
 
-  const { enabledTlds = Object.keys(tldLocales) } =
-    await chrome.storage.sync.get('enabledTlds');
-  const tldSet = new Set(enabledTlds);
+  const { enabledCountries = Object.keys(countryLocales) } =
+    await chrome.storage.sync.get('enabledCountries');
+  const countrySet = new Set(enabledCountries);
 
-  if (enabled) tldSet.add(tld);
-  else tldSet.delete(tld);
+  if (enabled) countrySet.add(countryCode);
+  else countrySet.delete(countryCode);
 
-  await chrome.storage.sync.set({ enabledTlds: [...tldSet] });
+  await chrome.storage.sync.set({ enabledCountries: [...countrySet] });
 }


### PR DESCRIPTION
## Problem

The global context search sample still suggested that selecting a country switched to that country's Google domain. As noted in #1653, country-specific Google domains no longer provide a useful visible difference for this sample.

## Root cause

The sample encoded locale choice as Google Search hostnames such as `google.ca` or `google.co.jp`, so the UI described obsolete domain switching instead of an explicit search-region behavior.

## Solution

Use `https://www.google.com/search` for all searches and add the Google Search `cr=countryXX` country restriction parameter based on the selected context-menu item. Rename the sample UI/storage identifiers from TLDs to countries and refresh the README/manifest copy to describe country-restricted results.

## Tests run

- `npx eslint --no-warn-ignored api-samples/contextMenus/global_context_search/background.js api-samples/contextMenus/global_context_search/popup.js --quiet`
- `npx prettier --check api-samples/contextMenus/global_context_search/background.js api-samples/contextMenus/global_context_search/locales.js api-samples/contextMenus/global_context_search/popup.js api-samples/contextMenus/global_context_search/popup.html api-samples/contextMenus/global_context_search/manifest.json api-samples/contextMenus/global_context_search/README.md`
- `git diff --check HEAD~1..HEAD`
- Node smoke test with mocked `chrome.*` APIs verifying menu creation, `cr=countryCA` search URLs, and country storage updates

Fixes #1653