### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Related issue
+
+<!-- Link the issue this PR addresses. New samples should have an approved issue before a PR is opened. -->
+
+## Changes
+
+<!-- Briefly describe what changed and why. -->
+
+## Testing
+
+<!-- Describe the Chrome version, platform, and manual steps used to verify the sample. -->
+
+## Additional notes
+
+<!-- Add screenshots, recordings, or migration notes when they help reviewers. -->


### PR DESCRIPTION
Problem
The repository has an issue template, but PR authors do not get a lightweight prompt to link the related issue or explain how a sample was tested. Issue #1113 tracks adding a basic PR template.

Root cause
There is no .github/pull_request_template.md file, so contributors start from a blank PR body.

Solution
Add a concise PR template with sections for the related issue, change summary, testing notes, and any additional reviewer context. The template intentionally avoids lint/checklist requirements per the maintainer guidance on #1113.

Tests run
- npx prettier --check .github/pull_request_template.md
- git diff --cached --check

Linked issue
Closes #1113