### PR TITLE
Fix side panel open sample ordering

### DIFF
--- a/functional-samples/cookbook.sidepanel-open/README.md
+++ b/functional-samples/cookbook.sidepanel-open/README.md
@@ -1,6 +1,6 @@
 # Opening the side panel through a user interaction
 
-This example demonstrates using [`chrome.sidePanel.open()`](https://developer.chrome.com/docs/extensions/reference/sidePanel/#method-open) to open a global side panel through a context menu click and a tab-specific side panel by clicking a button in an extension page or a button click injected by a content script. This feature will be available starting **Chrome 116**.
+This example demonstrates using [`chrome.sidePanel.open()`](https://developer.chrome.com/docs/extensions/reference/sidePanel/#method-open) to open a global side panel through a context menu click and a tab-specific side panel by clicking a button in an extension page or a button click injected by a content script. This feature is available starting **Chrome 116**.
 
 ## Running this extension
 

--- a/functional-samples/cookbook.sidepanel-open/content-script.js
+++ b/functional-samples/cookbook.sidepanel-open/content-script.js
@@ -5,4 +5,12 @@ const button = new DOMParser().parseFromString(
 button.addEventListener('click', function () {
   chrome.runtime.sendMessage({ type: 'open_side_panel' });
 });
-document.body.append(button);
+
+chrome.runtime.sendMessage({ type: 'configure_side_panel' }, (response) => {
+  if (chrome.runtime.lastError || response?.error) {
+    console.error(chrome.runtime.lastError?.message || response.error);
+    return;
+  }
+
+  document.body.append(button);
+});

--- a/functional-samples/cookbook.sidepanel-open/script.js
+++ b/functional-samples/cookbook.sidepanel-open/script.js
@@ -6,11 +6,15 @@ const [tab] = await chrome.tabs.query({
 
 const tabId = tab.id;
 const button = document.getElementById('openSidePanel');
+button.disabled = true;
+
+await chrome.sidePanel.setOptions({
+  tabId,
+  path: 'sidepanel-tab.html',
+  enabled: true
+});
+button.disabled = false;
+
 button.addEventListener('click', async () => {
   await chrome.sidePanel.open({ tabId });
-  await chrome.sidePanel.setOptions({
-    tabId,
-    path: 'sidepanel-tab.html',
-    enabled: true
-  });
 });

--- a/functional-samples/cookbook.sidepanel-open/service-worker.js
+++ b/functional-samples/cookbook.sidepanel-open/service-worker.js
@@ -28,17 +28,27 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   }
 });
 
-chrome.runtime.onMessage.addListener((message, sender) => {
-  // The callback for runtime.onMessage must return falsy if we're not sending a response
-  (async () => {
-    if (message.type === 'open_side_panel') {
-      // This will open a tab-specific side panel only on the current tab.
-      await chrome.sidePanel.open({ tabId: sender.tab.id });
-      await chrome.sidePanel.setOptions({
-        tabId: sender.tab.id,
-        path: 'sidepanel-tab.html',
-        enabled: true
-      });
-    }
-  })();
+async function setSidePanelOptions(tabId) {
+  await chrome.sidePanel.setOptions({
+    tabId,
+    path: 'sidepanel-tab.html',
+    enabled: true
+  });
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  const tabId = sender.tab?.id;
+
+  if (message.type === 'configure_side_panel' && typeof tabId === 'number') {
+    setSidePanelOptions(tabId)
+      .then(() => sendResponse())
+      .catch((error) => sendResponse({ error: error.message }));
+    return true;
+  }
+
+  // The callback for runtime.onMessage must return falsy if we're not sending a response.
+  if (message.type === 'open_side_panel' && typeof tabId === 'number') {
+    // This will open a tab-specific side panel only on the current tab.
+    chrome.sidePanel.open({ tabId });
+  }
 });


### PR DESCRIPTION
Fixes #1477.

## Problem

The `cookbook.sidepanel-open` sample opened the tab-specific side panel before setting the tab-specific `path`. On the first click, Chrome showed the default side panel page; only a second click showed `sidepanel-tab.html`.

## Root cause

`chrome.sidePanel.open()` must run during the user gesture, but the sample configured `chrome.sidePanel.setOptions()` after opening the panel. Reversing those calls inside the click handler would lose the user gesture before `open()` runs.

## Solution

Preconfigure the tab-specific side panel path before the button is enabled or appended to the page. The click handlers now only call `chrome.sidePanel.open()`, so the first click opens the intended side panel page while preserving the user gesture requirement.

## Tests

- `npx eslint functional-samples/cookbook.sidepanel-open/content-script.js functional-samples/cookbook.sidepanel-open/script.js functional-samples/cookbook.sidepanel-open/service-worker.js`
- `npx prettier --check functional-samples/cookbook.sidepanel-open/README.md functional-samples/cookbook.sidepanel-open/content-script.js functional-samples/cookbook.sidepanel-open/script.js functional-samples/cookbook.sidepanel-open/service-worker.js`
- Node smoke check that the injected button is only appended after tab-specific setup and the extension page button is gated by setup
- `git diff --check origin/main..HEAD`