### PR TITLE
Update global context search sample to use country restrictions

### DIFF
--- a/api-samples/contextMenus/global_context_search/README.md
+++ b/api-samples/contextMenus/global_context_search/README.md
@@ -1,10 +1,10 @@
 # chrome.contextMenus
 
-This sample demonstrates the `chrome.contextMenus` API by letting a user switch between searching different countries' versions of Google via a `contextMenu`.
+This sample demonstrates the `chrome.contextMenus` API by letting a user search selected text with Google results restricted to a chosen country via a `contextMenu`.
 
 ## Overview
 
-The extension uses `chrome.contextMenus.create()` to populate the context menu with locale options based on an options menu in the popup. A `chrome.contextMenus.onClicked.addListener()` event will open a specific locale's Google homepage when one of the extension's context menu options are clicked.
+The extension uses `chrome.contextMenus.create()` to populate the context menu with country options based on the popup settings. A `chrome.contextMenus.onClicked.addListener()` event opens Google Search with a country restriction when one of the extension's context menu options is clicked.
 
 ## Running this extension
 

--- a/api-samples/contextMenus/global_context_search/background.js
+++ b/api-samples/contextMenus/global_context_search/background.js
@@ -4,15 +4,15 @@
 
 // When you specify "type": "module" in the manifest background,
 // you can include the service worker as an ES Module,
-import { tldLocales } from './locales.js';
+import { regionOptions } from './locales.js';
 
 // Add a listener to create the initial context menu items,
 // context menu items only need to be created at runtime.onInstalled
 chrome.runtime.onInstalled.addListener(async () => {
-  for (const [tld, locale] of Object.entries(tldLocales)) {
+  for (const [region, label] of Object.entries(regionOptions)) {
     chrome.contextMenus.create({
-      id: tld,
-      title: locale,
+      id: region,
+      title: label,
       type: 'normal',
       contexts: ['selection']
     });
@@ -21,36 +21,37 @@ chrome.runtime.onInstalled.addListener(async () => {
 
 // Open a new search tab when the user clicks a context menu
 chrome.contextMenus.onClicked.addListener((item, tab) => {
-  const tld = item.menuItemId;
-  const url = new URL(`https://google.${tld}/search`);
+  const region = item.menuItemId;
+  const url = new URL('https://www.google.com/search');
   url.searchParams.set('q', item.selectionText);
+  url.searchParams.set('cr', `country${region}`);
   chrome.tabs.create({ url: url.href, index: tab.index + 1 });
 });
 
-// Add or removes the locale from context menu
-// when the user checks or unchecks the locale in the popup
-chrome.storage.onChanged.addListener(({ enabledTlds }) => {
-  if (typeof enabledTlds === 'undefined') return;
+// Add or remove regions from the context menu
+// when the user checks or unchecks a region in the popup
+chrome.storage.onChanged.addListener(({ enabledRegions }) => {
+  if (typeof enabledRegions === 'undefined') return;
 
-  const allTlds = Object.keys(tldLocales);
-  const currentTlds = new Set(enabledTlds.newValue);
-  const oldTlds = new Set(enabledTlds.oldValue ?? allTlds);
-  const changes = allTlds.map((tld) => ({
-    tld,
-    added: currentTlds.has(tld) && !oldTlds.has(tld),
-    removed: !currentTlds.has(tld) && oldTlds.has(tld)
+  const allRegions = Object.keys(regionOptions);
+  const currentRegions = new Set(enabledRegions.newValue);
+  const oldRegions = new Set(enabledRegions.oldValue ?? allRegions);
+  const changes = allRegions.map((region) => ({
+    region,
+    added: currentRegions.has(region) && !oldRegions.has(region),
+    removed: !currentRegions.has(region) && oldRegions.has(region)
   }));
 
-  for (const { tld, added, removed } of changes) {
+  for (const { region, added, removed } of changes) {
     if (added) {
       chrome.contextMenus.create({
-        id: tld,
-        title: tldLocales[tld],
+        id: region,
+        title: regionOptions[region],
         type: 'normal',
         contexts: ['selection']
       });
     } else if (removed) {
-      chrome.contextMenus.remove(tld);
+      chrome.contextMenus.remove(region);
     }
   }
 });

--- a/api-samples/contextMenus/global_context_search/locales.js
+++ b/api-samples/contextMenus/global_context_search/locales.js
@@ -2,18 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TLD: top level domain; the "com" in "google.com"
-export const tldLocales = {
-  'com.au': 'Australia',
-  'com.br': 'Brazil',
-  ca: 'Canada',
-  cn: 'China',
-  fr: 'France',
-  it: 'Italy',
-  'co.in': 'India',
-  'co.jp': 'Japan',
-  'com.ms': 'Mexico',
-  ru: 'Russia',
-  'co.za': 'South Africa',
-  'co.uk': 'United Kingdom'
+// Google Search's `cr` parameter restricts results by country.
+export const regionOptions = {
+  AU: 'Australia',
+  BR: 'Brazil',
+  CA: 'Canada',
+  CN: 'China',
+  FR: 'France',
+  IT: 'Italy',
+  IN: 'India',
+  JP: 'Japan',
+  MX: 'Mexico',
+  RU: 'Russia',
+  ZA: 'South Africa',
+  UK: 'United Kingdom'
 };

--- a/api-samples/contextMenus/global_context_search/manifest.json
+++ b/api-samples/contextMenus/global_context_search/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Global Google Search",
-  "description": "Uses the context menu to search a different country's Google",
+  "description": "Uses the context menu to search Google results for a selected country",
   "version": "1.1",
   "manifest_version": 3,
   "permissions": ["contextMenus", "storage"],

--- a/api-samples/contextMenus/global_context_search/popup.js
+++ b/api-samples/contextMenus/global_context_search/popup.js
@@ -2,28 +2,27 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TLD: top level domain; the "com" in "google.com"
-import { tldLocales } from './locales.js';
+import { regionOptions } from './locales.js';
 
 createForm().catch(console.error);
 
 async function createForm() {
-  const { enabledTlds = Object.keys(tldLocales) } =
-    await chrome.storage.sync.get('enabledTlds');
-  const checked = new Set(enabledTlds);
+  const { enabledRegions = Object.keys(regionOptions) } =
+    await chrome.storage.sync.get('enabledRegions');
+  const checked = new Set(enabledRegions);
 
   const form = document.getElementById('form');
-  for (const [tld, locale] of Object.entries(tldLocales)) {
+  for (const [region, label] of Object.entries(regionOptions)) {
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
-    checkbox.checked = checked.has(tld);
-    checkbox.name = tld;
+    checkbox.checked = checked.has(region);
+    checkbox.name = region;
     checkbox.addEventListener('click', (event) => {
       handleCheckboxClick(event).catch(console.error);
     });
 
     const span = document.createElement('span');
-    span.textContent = locale;
+    span.textContent = label;
 
     const div = document.createElement('div');
     div.appendChild(checkbox);
@@ -35,15 +34,15 @@ async function createForm() {
 
 async function handleCheckboxClick(event) {
   const checkbox = event.target;
-  const tld = checkbox.name;
+  const region = checkbox.name;
   const enabled = checkbox.checked;
 
-  const { enabledTlds = Object.keys(tldLocales) } =
-    await chrome.storage.sync.get('enabledTlds');
-  const tldSet = new Set(enabledTlds);
+  const { enabledRegions = Object.keys(regionOptions) } =
+    await chrome.storage.sync.get('enabledRegions');
+  const regionSet = new Set(enabledRegions);
 
-  if (enabled) tldSet.add(tld);
-  else tldSet.delete(tld);
+  if (enabled) regionSet.add(region);
+  else regionSet.delete(region);
 
-  await chrome.storage.sync.set({ enabledTlds: [...tldSet] });
+  await chrome.storage.sync.set({ enabledRegions: [...regionSet] });
 }


### PR DESCRIPTION
## Problem

The `global_context_search` sample still demonstrates country-specific Google searches by switching between Google country-code domains. That no longer produces a meaningful visible difference in Google Search results, which makes the sample feel outdated.

## Root cause

The sample stores country choices as Google TLDs and builds search URLs like `https://google.ca/search`. Google Search now generally localizes results independently from the selected domain.

## Solution

Keep the same `chrome.contextMenus` flow, but model the popup/menu choices as country regions and open `https://www.google.com/search` with the `cr=countryXX` search parameter. The README and manifest description now describe country-restricted Google results instead of different country domains.

## Tests run

- `npx eslint api-samples/contextMenus/global_context_search/background.js api-samples/contextMenus/global_context_search/locales.js api-samples/contextMenus/global_context_search/popup.js`
- `npm exec --yes --package prettier@3.3.3 -- prettier --check api-samples/contextMenus/global_context_search/README.md api-samples/contextMenus/global_context_search/manifest.json api-samples/contextMenus/global_context_search/background.js api-samples/contextMenus/global_context_search/locales.js api-samples/contextMenus/global_context_search/popup.js`
- `git diff --check`

Fixes #1653