### PR TITLE
Bump prettier from 3.3.3 to 3.9.5

### DIFF
--- a/api-samples/fontSettings/fontSettings Advanced/js/cr.js
+++ b/api-samples/fontSettings/fontSettings Advanced/js/cr.js
@@ -42,7 +42,7 @@ this.cr = (function () {
     let parts = name.split('.');
     let cur = opt_objectToExportTo || global;
 
-    for (let part; parts.length && (part = parts.shift()); ) {
+    for (let part; parts.length && (part = parts.shift());) {
       if (!parts.length && opt_object !== undefined) {
         // last part and we have an object; use it
         cur[part] = opt_object;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "globals": "15.14.0",
         "husky": "9.1.7",
         "lint-staged": "17.0.8",
-        "prettier": "3.3.3"
+        "prettier": "3.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1690,10 +1690,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3223,9 +3224,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "globals": "15.14.0",
     "husky": "9.1.7",
     "lint-staged": "17.0.8",
-    "prettier": "3.3.3"
+    "prettier": "3.9.5"
   },
   "lint-staged": {
     "**/*.js": [


### PR DESCRIPTION
Replaces #1500, which dependabot lost the state for and can no longer rebase. One formatting fix in fontSettings' cr.js that the new prettier requires.