### PR TITLE
Add offscreen user media recording sample

### DIFF
--- a/functional-samples/cookbook.offscreen-user-media/README.md
+++ b/functional-samples/cookbook.offscreen-user-media/README.md
@@ -1,0 +1,21 @@
+This recipe shows how to record microphone audio with `getUserMedia()` in
+an [offscreen document][1].
+
+`getUserMedia()` inside an offscreen document cannot show a permission
+prompt. The permission has to be granted to the extension's origin from a
+regular extension page first; after that, the offscreen document can record
+without any visible surface. This sample prompts from a page opened in a
+tab, records in the offscreen document, and offers the finished recording
+in the popup for playback and download.
+
+## Running this extension
+
+1. Clone this repository.
+2. Load this directory in Chrome as an [unpacked extension][2].
+3. Click the extension's action icon and press "Start recording". The first
+   use opens a tab asking for microphone access; the tab closes itself once
+   access is granted. Press "Start recording" again to begin recording.
+4. Press "Stop recording" to play back or download the recording.
+
+[1]: https://developer.chrome.com/docs/extensions/reference/api/offscreen
+[2]: https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked

--- a/functional-samples/cookbook.offscreen-user-media/background.js
+++ b/functional-samples/cookbook.offscreen-user-media/background.js
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const OFFSCREEN_URL = 'offscreen/offscreen.html';
+
+let creating;
+
+async function ensureOffscreenDocument() {
+  const contexts = await chrome.runtime.getContexts({
+    contextTypes: ['OFFSCREEN_DOCUMENT']
+  });
+  if (contexts.length > 0) {
+    return;
+  }
+  if (!creating) {
+    creating = chrome.offscreen
+      .createDocument({
+        url: OFFSCREEN_URL,
+        reasons: ['USER_MEDIA'],
+        justification: 'Recording microphone audio'
+      })
+      .finally(() => {
+        creating = undefined;
+      });
+  }
+  await creating;
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.target !== 'background') {
+    return;
+  }
+  handleMessage(message).then(sendResponse, (error) =>
+    sendResponse({ state: 'idle', error: error.message })
+  );
+  return true;
+});
+
+async function handleMessage(message) {
+  switch (message.type) {
+    case 'start-recording': {
+      await ensureOffscreenDocument();
+      // getUserMedia in an offscreen document cannot show a permission
+      // prompt, so permission has to be granted to the extension origin
+      // from a regular extension page first.
+      const { state } = await chrome.runtime.sendMessage({
+        target: 'offscreen',
+        type: 'get-permission-state'
+      });
+      if (state === 'denied') {
+        return { state: 'permission-denied' };
+      }
+      if (state !== 'granted') {
+        await chrome.tabs.create({
+          url: chrome.runtime.getURL('permission.html')
+        });
+        return { state: 'permission-needed' };
+      }
+      return chrome.runtime.sendMessage({
+        target: 'offscreen',
+        type: 'start'
+      });
+    }
+    case 'stop-recording':
+      return chrome.runtime.sendMessage({
+        target: 'offscreen',
+        type: 'stop'
+      });
+    case 'get-state': {
+      const contexts = await chrome.runtime.getContexts({
+        contextTypes: ['OFFSCREEN_DOCUMENT']
+      });
+      if (contexts.length === 0) {
+        return { state: 'idle' };
+      }
+      return chrome.runtime.sendMessage({
+        target: 'offscreen',
+        type: 'get-state'
+      });
+    }
+    default:
+      console.warn(`Unexpected message type received: '${message.type}'.`);
+  }
+}

--- a/functional-samples/cookbook.offscreen-user-media/manifest.json
+++ b/functional-samples/cookbook.offscreen-user-media/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "Offscreen API - Record User Media",
+  "version": "1.0",
+  "manifest_version": 3,
+  "minimum_chrome_version": "116",
+  "description": "Records microphone audio in an offscreen document.",
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "permissions": ["offscreen"]
+}

--- a/functional-samples/cookbook.offscreen-user-media/offscreen/offscreen.html
+++ b/functional-samples/cookbook.offscreen-user-media/offscreen/offscreen.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="offscreen.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/functional-samples/cookbook.offscreen-user-media/offscreen/offscreen.js
+++ b/functional-samples/cookbook.offscreen-user-media/offscreen/offscreen.js
@@ -1,0 +1,83 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+let recorder;
+let chunks = [];
+let lastRecordingUrl;
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.target !== 'offscreen') {
+    return;
+  }
+  handleMessage(message).then(sendResponse, (error) =>
+    sendResponse({ state: 'idle', error: error.message })
+  );
+  return true;
+});
+
+async function handleMessage(message) {
+  switch (message.type) {
+    case 'get-permission-state': {
+      const { state } = await navigator.permissions.query({
+        name: 'microphone'
+      });
+      return { state };
+    }
+    case 'get-state':
+      return {
+        state: recorder?.state === 'recording' ? 'recording' : 'idle',
+        recordingUrl: lastRecordingUrl
+      };
+    case 'start':
+      return startRecording();
+    case 'stop':
+      recorder?.stop();
+      return { state: 'idle' };
+    default:
+      console.warn(`Unexpected message type received: '${message.type}'.`);
+  }
+}
+
+async function startRecording() {
+  if (recorder?.state === 'recording') {
+    return { state: 'recording' };
+  }
+  let stream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (error) {
+    return { state: 'idle', error: error.message };
+  }
+  chunks = [];
+  recorder = new MediaRecorder(stream, { mimeType: 'audio/webm' });
+  recorder.ondataavailable = (event) => chunks.push(event.data);
+  recorder.onstop = () => {
+    stream.getTracks().forEach((track) => track.stop());
+    if (lastRecordingUrl) {
+      URL.revokeObjectURL(lastRecordingUrl);
+    }
+    // Object URLs stay valid for other extension pages as long as this
+    // offscreen document exists.
+    lastRecordingUrl = URL.createObjectURL(
+      new Blob(chunks, { type: 'audio/webm' })
+    );
+    chrome.runtime.sendMessage({
+      target: 'popup',
+      type: 'recording-ready',
+      url: lastRecordingUrl
+    });
+  };
+  recorder.start();
+  return { state: 'recording' };
+}

--- a/functional-samples/cookbook.offscreen-user-media/permission.html
+++ b/functional-samples/cookbook.offscreen-user-media/permission.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Microphone access</title>
+  </head>
+  <body>
+    <p>
+      Chrome will ask for microphone access. Granting it lets the extension
+      record from its popup; this tab closes itself afterwards.
+    </p>
+    <p id="status"></p>
+    <script src="permission.js"></script>
+  </body>
+</html>

--- a/functional-samples/cookbook.offscreen-user-media/permission.js
+++ b/functional-samples/cookbook.offscreen-user-media/permission.js
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+navigator.mediaDevices
+  .getUserMedia({ audio: true })
+  .then((stream) => {
+    // The stream is unused; this page exists to trigger the permission
+    // prompt.
+    stream.getTracks().forEach((track) => track.stop());
+    window.close();
+  })
+  .catch((error) => {
+    document.getElementById('status').textContent =
+      'Microphone access was not granted: ' + error.message;
+  });

--- a/functional-samples/cookbook.offscreen-user-media/popup.html
+++ b/functional-samples/cookbook.offscreen-user-media/popup.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        width: 220px;
+        font-family: system-ui;
+      }
+      audio {
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <button id="start">Start recording</button>
+    <button id="stop" disabled>Stop recording</button>
+    <p id="status">Loading...</p>
+    <div id="result" hidden>
+      <audio id="playback" controls></audio>
+      <a id="download" download="recording.webm">Download recording</a>
+    </div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/functional-samples/cookbook.offscreen-user-media/popup.js
+++ b/functional-samples/cookbook.offscreen-user-media/popup.js
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const STATUS_TEXT = {
+  idle: 'Ready to record.',
+  recording: 'Recording...',
+  'permission-needed': 'Grant microphone access in the opened tab.',
+  'permission-denied':
+    'Microphone access is blocked for this extension. Reset it under ' +
+    'chrome://settings/content/microphone, then try again.'
+};
+
+const startButton = document.getElementById('start');
+const stopButton = document.getElementById('stop');
+const status = document.getElementById('status');
+
+function showState({ state, error, recordingUrl }) {
+  startButton.disabled = state === 'recording';
+  stopButton.disabled = state !== 'recording';
+  status.textContent = error ?? STATUS_TEXT[state] ?? 'Something went wrong.';
+  if (recordingUrl) {
+    showRecording(recordingUrl);
+  }
+}
+
+function showRecording(url) {
+  document.getElementById('result').hidden = false;
+  document.getElementById('playback').src = url;
+  document.getElementById('download').href = url;
+}
+
+startButton.onclick = async () => {
+  startButton.disabled = true;
+  showState(
+    await chrome.runtime.sendMessage({
+      target: 'background',
+      type: 'start-recording'
+    })
+  );
+};
+
+stopButton.onclick = async () => {
+  showState(
+    await chrome.runtime.sendMessage({
+      target: 'background',
+      type: 'stop-recording'
+    })
+  );
+};
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.target !== 'popup') {
+    return;
+  }
+  if (message.type === 'recording-ready') {
+    showState({ state: 'idle', recordingUrl: message.url });
+  }
+});
+
+chrome.runtime
+  .sendMessage({ target: 'background', type: 'get-state' })
+  .then(showState);


### PR DESCRIPTION
Adds cookbook.offscreen-user-media: records microphone audio in an offscreen document. getUserMedia in an offscreen document cannot show a permission prompt, so a regular extension page opened in a tab grants mic access to the extension origin first; the popup then drives recording and offers the result for playback and download. Fixes #821. Thanks to @aakash232, whose #1056 worked out the permission approach this builds on.