### PR TITLE
Add a workflow to auto-merge Dependabot pull requests

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+# Approves and enables auto-merge on Dependabot pull requests once the repo's
+# own CI has passed. Auto-merge means GitHub does the merge itself when every
+# required check is green, so this workflow never merges anything unchecked.
+#
+# Scope: version-update PRs that are patch or minor, plus any security update.
+# Major bumps are left for a human.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch update metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Approve and enable auto-merge
+        if: >-
+          steps.meta.outputs.update-type != 'version-update:semver-major'
+          || steps.meta.outputs.ghsa-id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review "$PR" --approve
+          gh pr merge "$PR" --auto --squash

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,12 +15,13 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    # Matched on the account ID rather than the login, which is spoofable.
+    if: github.event.pull_request.user.id == 49699333 # dependabot[bot]
     runs-on: ubuntu-latest
     steps:
       - name: Fetch update metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
       - name: Approve and enable auto-merge
         if: >-


### PR DESCRIPTION
Dependabot pull requests here are approved and merged by hand. This adds a
workflow that does it instead: it approves the PR and turns on auto-merge, and
GitHub performs the merge once the required check passes.

Scope is patch and minor version updates, plus security updates at any version.
Major bumps are skipped so a human still looks at them.

Two repository settings back this up and are already in place:

- `build`, from the CI workflow, is now a required status check on `main`, so
  auto-merge has something real to wait for. It is the only check defined in
  this repository, and so the only one whose name we control.
- "Allow auto-merge" is enabled.

"Require branches to be up to date before merging" stays on. It means the queue
drains at one PR per CI cycle rather than all at once, but it also means a batch
of updates touching the same lockfile gets built together before anything lands,
instead of merging cleanly as text and only being built afterwards.
