### PR TITLE
Use the built-in fetch in the sample list generator

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24
     - name: Install modules
       run: npm ci
     - name: Run ESLint
@@ -42,6 +45,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
       - name: Install modules
         run: npm ci
       - name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,8 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build --if-present
+      - name: Test
+        run: npm run test --if-present
 
   # A matrix reports one check per leg, so branch protection has no single name
   # to require. This job gives it one.

--- a/.github/workflows/sample-list-generator.yml
+++ b/.github/workflows/sample-list-generator.yml
@@ -8,16 +8,22 @@ defaults:
   run:
     working-directory: ./.repo/sample-list-generator
 
+# This job only reads the checkout; the artifact upload needs nothing more.
+permissions:
+  contents: read
+
 jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Install dependencies
         run: npm install
@@ -26,7 +32,7 @@ jobs:
         run: npm run start
 
       - name: Upload to artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: extension-samples.json
           path: ./.repo/sample-list-generator/extension-samples.json

--- a/.repo/sample-list-generator/package-lock.json
+++ b/.repo/sample-list-generator/package-lock.json
@@ -9,13 +9,12 @@
       "version": "1.0.0",
       "dependencies": {
         "@babel/core": "7.22.5",
-        "node-fetch": "2.6.11",
         "typedoc": "0.28.20"
       },
       "devDependencies": {
         "@types/babel__core": "7.20.1",
         "@types/mocha": "10.0.1",
-        "@types/node-fetch": "2.6.4",
+        "@types/node": "18.19.130",
         "@types/sinon": "10.0.15",
         "mocha": "10.2.0",
         "sinon": "15.2.0",
@@ -553,19 +552,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
-      "dev": true
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
-      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/sinon": {
@@ -661,12 +654,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -799,18 +786,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -851,15 +826,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/diff": {
@@ -941,20 +907,6 @@
       "dev": true,
       "bin": {
         "flat": "cli.js"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -1369,27 +1321,6 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
       "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg=="
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -1520,25 +1451,6 @@
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-releases": {
@@ -1800,11 +1712,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -1929,6 +1836,13 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -1949,20 +1863,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/workerpool": {
       "version": "6.2.1",
@@ -2557,19 +2457,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
-      "dev": true
-    },
-    "@types/node-fetch": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
-      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
+        "undici-types": "~5.26.4"
       }
     },
     "@types/sinon": {
@@ -2644,12 +2537,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -2759,15 +2646,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2797,12 +2675,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "diff": {
@@ -2861,17 +2733,6 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
-    },
-    "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -3178,21 +3039,6 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
       "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg=="
     },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.52.0"
-      }
-    },
     "minimatch": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -3299,14 +3145,6 @@
             "type-detect": "4.0.8"
           }
         }
-      }
-    },
-    "node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
       }
     },
     "node-releases": {
@@ -3513,11 +3351,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -3590,6 +3423,12 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "update-browserslist-db": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -3604,20 +3443,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "workerpool": {
       "version": "6.2.1",

--- a/.repo/sample-list-generator/package-lock.json
+++ b/.repo/sample-list-generator/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/babel__core": "7.20.1",
         "@types/mocha": "10.0.1",
-        "@types/node": "18.19.130",
+        "@types/node": "24.13.3",
         "@types/sinon": "10.0.15",
         "mocha": "10.2.0",
         "sinon": "15.2.0",
@@ -552,13 +552,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/sinon": {
@@ -1837,9 +1837,9 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2457,12 +2457,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.18.0"
       }
     },
     "@types/sinon": {
@@ -3424,9 +3424,9 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/.repo/sample-list-generator/package.json
+++ b/.repo/sample-list-generator/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@types/babel__core": "7.20.1",
     "@types/mocha": "10.0.1",
-    "@types/node-fetch": "2.6.4",
+    "@types/node": "18.19.130",
     "@types/sinon": "10.0.15",
     "mocha": "10.2.0",
     "sinon": "15.2.0",
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@babel/core": "7.22.5",
-    "node-fetch": "2.6.11",
     "typedoc": "0.28.20"
   }
 }

--- a/.repo/sample-list-generator/package.json
+++ b/.repo/sample-list-generator/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@types/babel__core": "7.20.1",
     "@types/mocha": "10.0.1",
-    "@types/node": "18.19.130",
+    "@types/node": "24.13.3",
     "@types/sinon": "10.0.15",
     "mocha": "10.2.0",
     "sinon": "15.2.0",

--- a/.repo/sample-list-generator/src/prepare-chrome-types.ts
+++ b/.repo/sample-list-generator/src/prepare-chrome-types.ts
@@ -1,31 +1,30 @@
-import fetch from 'node-fetch';
 import path from 'path';
 import fs from 'fs/promises';
 import { ExtensionApiMap } from './types';
 import { ReflectionKind } from 'typedoc';
 
-// Bucket used to store processed types data
-const STORAGE_BUCKET = process.env.STORAGE_BUCKET;
-
 // Fetch the latest version of the chrome types from storage
-const fetchChromeTypes = async (): Promise<Record<string, any>> => {
-  if (!STORAGE_BUCKET) {
+export const fetchChromeTypes = async (): Promise<Record<string, any>> => {
+  // Bucket used to store processed types data
+  const storageBucket = process.env.STORAGE_BUCKET;
+
+  if (!storageBucket) {
     throw new Error('The STORAGE_BUCKET environment variable must be set.');
   }
 
   console.log('Fetching chrome types...');
 
   const response = await fetch(
-    `https://storage.googleapis.com/download/storage/v1/b/${STORAGE_BUCKET}/o/chrome-types.json?alt=media`
+    `https://storage.googleapis.com/download/storage/v1/b/${storageBucket}/o/chrome-types.json?alt=media`
   );
-  const chromeTypes = await response.json();
-  return chromeTypes;
+  return (await response.json()) as Record<string, any>;
 };
 
-const run = async () => {
+// Sort every property of every API into properties, methods, events or types
+export const toExtensionApiMap = (
+  chromeTypes: Record<string, any>
+): ExtensionApiMap => {
   const result: ExtensionApiMap = {};
-
-  const chromeTypes = await fetchChromeTypes();
 
   for (const [chromeApiKey, chromeApiDetails] of Object.entries(chromeTypes)) {
     const apiDetails: ExtensionApiMap[string] = {
@@ -61,6 +60,13 @@ const run = async () => {
     result[chromeApiKey] = apiDetails;
   }
 
+  return result;
+};
+
+const run = async () => {
+  const chromeTypes = await fetchChromeTypes();
+  const result = toExtensionApiMap(chromeTypes);
+
   console.log('Writing to file...');
   await fs.writeFile(
     path.join(__dirname, '../extension-apis.json'),
@@ -77,4 +83,7 @@ const run = async () => {
   console.log('Done!');
 };
 
-run();
+// Only run when invoked as a script, so the exports above stay importable.
+if (require.main === module) {
+  run();
+}

--- a/.repo/sample-list-generator/src/prepare-chrome-types.ts
+++ b/.repo/sample-list-generator/src/prepare-chrome-types.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import fs from 'fs/promises';
 import { ExtensionApiMap } from './types';
-import { ReflectionKind } from 'typedoc';
 
 // Fetch the latest version of the chrome types from storage
 export const fetchChromeTypes = async (): Promise<Record<string, any>> => {
@@ -21,9 +20,12 @@ export const fetchChromeTypes = async (): Promise<Record<string, any>> => {
 };
 
 // Sort every property of every API into properties, methods, events or types
-export const toExtensionApiMap = (
+export const toExtensionApiMap = async (
   chromeTypes: Record<string, any>
-): ExtensionApiMap => {
+): Promise<ExtensionApiMap> => {
+  // typedoc 0.28+ ships as ESM only, so it cannot be require()d from this
+  // CommonJS module; load it dynamically instead.
+  const { ReflectionKind } = await import('typedoc');
   const result: ExtensionApiMap = {};
 
   for (const [chromeApiKey, chromeApiDetails] of Object.entries(chromeTypes)) {
@@ -65,7 +67,7 @@ export const toExtensionApiMap = (
 
 const run = async () => {
   const chromeTypes = await fetchChromeTypes();
-  const result = toExtensionApiMap(chromeTypes);
+  const result = await toExtensionApiMap(chromeTypes);
 
   console.log('Writing to file...');
   await fs.writeFile(

--- a/.repo/sample-list-generator/test/prepare-chrome-types/prepare-chrome-types.test.ts
+++ b/.repo/sample-list-generator/test/prepare-chrome-types/prepare-chrome-types.test.ts
@@ -1,13 +1,21 @@
-import { describe, it, afterEach } from 'mocha';
+import { describe, it, before, afterEach } from 'mocha';
 import assert from 'assert';
 import sinon from 'sinon';
-import { ReflectionKind } from 'typedoc';
 import {
   fetchChromeTypes,
   toExtensionApiMap
 } from '../../src/prepare-chrome-types';
 
+// typedoc 0.28+ ships as ESM only; see toExtensionApiMap. TypeScript 5.1
+// cannot reference its types from CommonJS either, so type the enum loosely.
+let ReflectionKind: Record<string, number>;
+
 describe('Prepare Chrome Types', function () {
+  before(async function () {
+    ReflectionKind = (await import('typedoc'))
+      .ReflectionKind as unknown as Record<string, number>;
+  });
+
   describe('fetchChromeTypes()', function () {
     const originalBucket = process.env.STORAGE_BUCKET;
 
@@ -55,8 +63,8 @@ describe('Prepare Chrome Types', function () {
   });
 
   describe('toExtensionApiMap()', function () {
-    it('should sort properties, methods, events and types', function () {
-      const result = toExtensionApiMap({
+    it('should sort properties, methods, events and types', async function () {
+      const result = await toExtensionApiMap({
         action: {
           _type: {
             properties: [
@@ -83,8 +91,8 @@ describe('Prepare Chrome Types', function () {
       });
     });
 
-    it('should treat every known event reference name as an event', function () {
-      const result = toExtensionApiMap({
+    it('should treat every known event reference name as an event', async function () {
+      const result = await toExtensionApiMap({
         events: {
           _type: {
             properties: [
@@ -121,8 +129,8 @@ describe('Prepare Chrome Types', function () {
       });
     });
 
-    it('should classify a property that also has signatures as a method', function () {
-      const result = toExtensionApiMap({
+    it('should classify a property that also has signatures as a method', async function () {
+      const result = await toExtensionApiMap({
         action: {
           _type: {
             properties: [
@@ -145,10 +153,10 @@ describe('Prepare Chrome Types', function () {
       });
     });
 
-    it('should handle multiple namespaces and an empty input', function () {
-      assert.deepEqual(toExtensionApiMap({}), {});
+    it('should handle multiple namespaces and an empty input', async function () {
+      assert.deepEqual(await toExtensionApiMap({}), {});
 
-      const result = toExtensionApiMap({
+      const result = await toExtensionApiMap({
         action: {
           _type: {
             properties: [{ name: 'a', kind: ReflectionKind.Property }]

--- a/.repo/sample-list-generator/test/prepare-chrome-types/prepare-chrome-types.test.ts
+++ b/.repo/sample-list-generator/test/prepare-chrome-types/prepare-chrome-types.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, afterEach } from 'mocha';
+import assert from 'assert';
+import sinon from 'sinon';
+import { ReflectionKind } from 'typedoc';
+import {
+  fetchChromeTypes,
+  toExtensionApiMap
+} from '../../src/prepare-chrome-types';
+
+describe('Prepare Chrome Types', function () {
+  describe('fetchChromeTypes()', function () {
+    const originalBucket = process.env.STORAGE_BUCKET;
+
+    afterEach(function () {
+      sinon.restore();
+      if (originalBucket === undefined) {
+        delete process.env.STORAGE_BUCKET;
+      } else {
+        process.env.STORAGE_BUCKET = originalBucket;
+      }
+    });
+
+    it('should throw when STORAGE_BUCKET is not set', async function () {
+      delete process.env.STORAGE_BUCKET;
+      await assert.rejects(fetchChromeTypes(), {
+        message: 'The STORAGE_BUCKET environment variable must be set.'
+      });
+    });
+
+    it('should request the types from the configured bucket', async function () {
+      process.env.STORAGE_BUCKET = 'a-bucket';
+      const fetchStub = sinon
+        .stub(globalThis, 'fetch')
+        .resolves(new Response('{}'));
+
+      await fetchChromeTypes();
+
+      assert.equal(fetchStub.callCount, 1);
+      assert.equal(
+        fetchStub.firstCall.args[0],
+        'https://storage.googleapis.com/download/storage/v1/b/a-bucket/o/chrome-types.json?alt=media'
+      );
+    });
+
+    it('should return the parsed response body', async function () {
+      process.env.STORAGE_BUCKET = 'a-bucket';
+      sinon
+        .stub(globalThis, 'fetch')
+        .resolves(new Response('{"action":{"_type":{"properties":[]}}}'));
+
+      const result = await fetchChromeTypes();
+
+      assert.deepEqual(result, { action: { _type: { properties: [] } } });
+    });
+  });
+
+  describe('toExtensionApiMap()', function () {
+    it('should sort properties, methods, events and types', function () {
+      const result = toExtensionApiMap({
+        action: {
+          _type: {
+            properties: [
+              { name: 'aProperty', kind: ReflectionKind.Property },
+              { name: 'aMethod', kind: ReflectionKind.Method, signatures: [] },
+              {
+                name: 'onClicked',
+                kind: ReflectionKind.Property,
+                type: { type: 'reference', name: 'events.Event' }
+              },
+              { name: 'ATypeName', kind: ReflectionKind.TypeAlias }
+            ]
+          }
+        }
+      });
+
+      assert.deepEqual(result, {
+        action: {
+          properties: ['aProperty'],
+          methods: ['aMethod'],
+          types: ['ATypeName'],
+          events: ['onClicked']
+        }
+      });
+    });
+
+    it('should treat every known event reference name as an event', function () {
+      const result = toExtensionApiMap({
+        events: {
+          _type: {
+            properties: [
+              {
+                name: 'custom',
+                kind: ReflectionKind.Property,
+                type: { type: 'reference', name: 'CustomChromeEvent' }
+              },
+              {
+                name: 'namespaced',
+                kind: ReflectionKind.Property,
+                type: { type: 'reference', name: 'events.Event' }
+              },
+              {
+                name: 'bare',
+                kind: ReflectionKind.Property,
+                type: { type: 'reference', name: 'Event' }
+              },
+              {
+                name: 'notAnEvent',
+                kind: ReflectionKind.Property,
+                type: { type: 'reference', name: 'SomethingElse' }
+              }
+            ]
+          }
+        }
+      });
+
+      assert.deepEqual(result.events, {
+        properties: ['notAnEvent'],
+        methods: [],
+        types: [],
+        events: ['custom', 'namespaced', 'bare']
+      });
+    });
+
+    it('should classify a property that also has signatures as a method', function () {
+      const result = toExtensionApiMap({
+        action: {
+          _type: {
+            properties: [
+              {
+                name: 'both',
+                kind: ReflectionKind.Property,
+                type: { type: 'reference', name: 'events.Event' },
+                signatures: []
+              }
+            ]
+          }
+        }
+      });
+
+      assert.deepEqual(result.action, {
+        properties: [],
+        methods: ['both'],
+        types: [],
+        events: []
+      });
+    });
+
+    it('should handle multiple namespaces and an empty input', function () {
+      assert.deepEqual(toExtensionApiMap({}), {});
+
+      const result = toExtensionApiMap({
+        action: {
+          _type: {
+            properties: [{ name: 'a', kind: ReflectionKind.Property }]
+          }
+        },
+        storage: {
+          _type: {
+            properties: [{ name: 'b', kind: ReflectionKind.Method, signatures: [] }]
+          }
+        }
+      });
+
+      assert.deepEqual(Object.keys(result), ['action', 'storage']);
+      assert.deepEqual(result.action.properties, ['a']);
+      assert.deepEqual(result.storage.methods, ['b']);
+    });
+  });
+});

--- a/.repo/sample-list-generator/tsconfig.json
+++ b/.repo/sample-list-generator/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "node16",
+    "moduleResolution": "node16",
+    "target": "es2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Closes #1750.

[`.repo/sample-list-generator`](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/.repo/sample-list-generator) is the only place in the repository that uses
node-fetch, in[ `src/prepare-chrome-types.ts`.](https://github.com/GoogleChrome/chrome-extensions-samples/blob/main/.repo/sample-list-generator/src/prepare-chrome-types.ts#L1). I was looking at upgraded to v3, but it breaks it. Specifically, 

- v3 is ESM only. Since the file isn't using  `tsconfig.json` or `"type": "module"`, 
  ts-node compiles the import down to `require()`. On Node 18.20.8, which is
  what the sample list workflow pins, that is `ERR_REQUIRE_ESM`. It happens to
  work on Node 22.12 and later, which can require ESM synchronously, so it
  fails on CI but would pass on a most peoples local.
- v3 bundles its own types, which shadow `@types/node-fetch`, and its `json()`
  returns `unknown` rather than `any`. The script stops compiling on every Node
  version with an assignment error `TS2322`.

Node 18 has had a global `fetch`, so the dependency is not needed at
all. This removes `node-fetch` and `@types/node-fetch` and uses the built-in.

`@types/node` is added because it was only reaching the project as a transitive
dependency of `@types/node-fetch`; removing that package would have taken the
typings for `process.env`, `__dirname` and `fs/promises` with it. It is pinned to @types/node 24.x, same as the workflow's Node 24.

CI also moves to Node 24. Node 18 went end of life in April 2025 and the sample
list workflow still pinned it, while `lint.yml` pinned nothing at all, so
`build` and the `samples` matrix ran on whatever Node the runner image happened
to ship. Both workflows now pin 24, the current LTS. Editing
`sample-list-generator.yml` means its three actions need commit pins to satisfy
the workflow scanner.

Nothing covered this script before. `fetchChromeTypes` and the sorting logic
are now exported and tested, `run()` only executes when the file is invoked
directly so importing it in a test does not make a network request, and the CI
matrix runs `npm run test --if-present` so the suite actually gates.
`sample-list-generator` is the only sample that defines a test script today.

Verified locally: 17 tests pass, `npm ci` is clean, and `npm run start` exits 0
on Node 24.
