### PR TITLE
Simplify the declarativeNetRequest URL redirect sample

### DIFF
--- a/api-samples/declarativeNetRequest/url-redirect/README.md
+++ b/api-samples/declarativeNetRequest/url-redirect/README.md
@@ -4,16 +4,8 @@ This sample demonstrates using the [`chrome.declarativeNetRequest`](https://deve
 
 ## Overview
 
-Once this extension is installed, any requests made in the main frame to the following URLs will be redirected:
-
-- https://developer.chrome.com/docs/extensions/mv2/
-- https://developer.chrome.com/docs/extensions/reference/browserAction/
-- https://developer.chrome.com/docs/extensions/reference/declarativeWebRequest/
-- https://developer.chrome.com/docs/extensions/reference/pageAction/
-- https://developer.chrome.com/docs/extensions/reference/webRequest/
+Once this extension is installed, any requests made in the main frame to https://example.com/original will be redirected to https://example.com/redirected.
 
 ## Implementation Notes
 
 This sample uses the `chrome.declarativeNetRequest.onRuleMatchedDebug` event which is only available in unpacked extensions.
-
-The rules match the `xmlhttprequest` resource type in addition to `main_frame`. For returning visitors, developer.chrome.com serves navigations through its service worker, so no `main_frame` network request is made; the request issued by the site's service worker is matched instead.

--- a/api-samples/declarativeNetRequest/url-redirect/manifest.json
+++ b/api-samples/declarativeNetRequest/url-redirect/manifest.json
@@ -20,5 +20,5 @@
     "declarativeNetRequestFeedback",
     "declarativeNetRequestWithHostAccess"
   ],
-  "host_permissions": ["https://developer.chrome.com/"]
+  "host_permissions": ["https://example.com/*"]
 }

--- a/api-samples/declarativeNetRequest/url-redirect/rules_1.json
+++ b/api-samples/declarativeNetRequest/url-redirect/rules_1.json
@@ -1,72 +1,15 @@
 [
   {
     "id": 1,
-    "priority": 1,
     "action": {
       "type": "redirect",
       "redirect": {
-        "url": "https://developer.chrome.com/docs/extensions/develop/migrate"
+        "url": "https://example.com/redirected"
       }
     },
     "condition": {
-      "urlFilter": "https://developer.chrome.com/docs/extensions/mv2",
-      "resourceTypes": ["main_frame", "xmlhttprequest"]
-    }
-  },
-  {
-    "id": 2,
-    "priority": 1,
-    "action": {
-      "type": "redirect",
-      "redirect": {
-        "url": "https://developer.chrome.com/docs/extensions/reference/api/action"
-      }
-    },
-    "condition": {
-      "urlFilter": "https://developer.chrome.com/docs/extensions/reference/browserAction",
-      "resourceTypes": ["main_frame", "xmlhttprequest"]
-    }
-  },
-  {
-    "id": 3,
-    "priority": 1,
-    "action": {
-      "type": "redirect",
-      "redirect": {
-        "url": "https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest"
-      }
-    },
-    "condition": {
-      "urlFilter": "https://developer.chrome.com/docs/extensions/reference/declarativeWebRequest",
-      "resourceTypes": ["main_frame", "xmlhttprequest"]
-    }
-  },
-  {
-    "id": 4,
-    "priority": 1,
-    "action": {
-      "type": "redirect",
-      "redirect": {
-        "url": "https://developer.chrome.com/docs/extensions/reference/api/action"
-      }
-    },
-    "condition": {
-      "urlFilter": "https://developer.chrome.com/docs/extensions/reference/pageAction",
-      "resourceTypes": ["main_frame", "xmlhttprequest"]
-    }
-  },
-  {
-    "id": 5,
-    "priority": 1,
-    "action": {
-      "type": "redirect",
-      "redirect": {
-        "url": "https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest"
-      }
-    },
-    "condition": {
-      "urlFilter": "https://developer.chrome.com/docs/extensions/reference/webRequest",
-      "resourceTypes": ["main_frame", "xmlhttprequest"]
+      "urlFilter": "||example.com/original",
+      "resourceTypes": ["main_frame"]
     }
   }
 ]


### PR DESCRIPTION
The five rules pointed at real developer.chrome.com pages, which made the sample look like broken navigation rather than a redirect demo. Replaced them with one rule redirecting example.com/original to example.com/redirected.

Fixes #1783